### PR TITLE
chore: Add EditorConfig file for basic formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This should autocleanup a few of those MarkdownLint warnings as files are edited throught the GitHub web UI