### PR TITLE
Configured Travis to display Jekyll build error messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,10 @@ node_js:
 rvm:
   - 2.2
 
-script: "bundle exec jekyll build"
+before_install: 
+  - bundle init
+  - bundle add github-pages
+
+before_script: 
+  - bundle exec jekyll build
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 
 node_js:
   - "node"
+
+rvm:
+- 2.1
+script: "bundle exec jekyll build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
   - "node"
 
 rvm:
-- 2.1
+  - 2.2
+
 script: "bundle exec jekyll build"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'github-pages'


### PR DESCRIPTION
Attempting to get this to work based upon:
- https://help.github.com/articles/viewing-jekyll-build-error-messages/
- https://stackoverflow.com/questions/31235146/how-to-run-node-js-and-ruby-tests-within-one-project-on-travis-ci?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa

Seems that Node and Ruby can be used together in the same VM.

The goal is to get better Jekyll build errors through Travis since the error messages coming out through the other way are pretty useless.