### PR TITLE
Moved h1 to the header include file

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "default": true,
+  "MD002": false,
   "MD013": false,
   "MD024": false,
   "MD036": false

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,5 +3,6 @@
   "MD002": false,
   "MD013": false,
   "MD024": false,
-  "MD036": false
+  "MD036": false,
+  "MD041": false
 }

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -95,3 +95,4 @@ defTop.outerHTML = wet.builder.top({
 });
 </script>
 <main role="main" property="mainContentOfPage" class="container">
+<h1 property="name" id="wb-cont">{{ page.title }}</h1>

--- a/en/1-design-with-users.md
+++ b/en/1-design-with-users.md
@@ -5,11 +5,6 @@ lang: en
 altLang: fr
 altLangPage: 1-concevoir-avec-utilisateurs
 ---
-<!-- markdownlint-disable MD022 -->
-# 1. Design with users (draft)
-{: property="name" #wb-cont}
-<!-- markdownlint-enable MD022 -->
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/1-design-with-users.md
+++ b/en/1-design-with-users.md
@@ -5,9 +5,10 @@ lang: en
 altLang: fr
 altLangPage: 1-concevoir-avec-utilisateurs
 ---
+<!-- markdownlint-disable MD022 -->
 # 1. Design with users (draft)
-
 {: property="name" #wb-cont}
+<!-- markdownlint-enable MD022 -->
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/1-design-with-users.md
+++ b/en/1-design-with-users.md
@@ -5,7 +5,8 @@ lang: en
 altLang: fr
 altLangPage: 1-concevoir-avec-utilisateurs
 ---
-# 1. Design with users (draft){: property="name" #wb-cont}
+# 1. Design with users (draft)
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/1-design-with-users.md
+++ b/en/1-design-with-users.md
@@ -6,6 +6,7 @@ altLang: fr
 altLangPage: 1-concevoir-avec-utilisateurs
 ---
 # 1. Design with users (draft)
+
 {: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**

--- a/en/10-be-good-data-stewards.md
+++ b/en/10-be-good-data-stewards.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: 10-soyez-bons-gestionnaires-donnees
 ---
-# 10. Be good data stewards (draft){: property="name" #wb-cont}
+# 10. Be good data stewards (draft)
+
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/10-be-good-data-stewards.md
+++ b/en/10-be-good-data-stewards.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: 10-soyez-bons-gestionnaires-donnees
 ---
-# 10. Be good data stewards (draft)
-
-{: property="name" #wb-cont}
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/2-build-in-accessibility-from-start.md
+++ b/en/2-build-in-accessibility-from-start.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: 2-construire-dans-accessibilite-des-debut
 ---
-# 2. Build in accessibility from the start (draft)
-
-{: property="name" #wb-cont}
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/2-build-in-accessibility-from-start.md
+++ b/en/2-build-in-accessibility-from-start.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: 2-construire-dans-accessibilite-des-debut
 ---
-# 2. Build in accessibility from the start (draft){: property="name" #wb-cont}
+# 2. Build in accessibility from the start (draft)
+
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/3-collaborate-widely.md
+++ b/en/3-collaborate-widely.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: 3-collaborez-largement
 ---
-# 3. Collaborate widely (draft){: property="name" #wb-cont}
+# 3. Collaborate widely (draft)
+
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/3-collaborate-widely.md
+++ b/en/3-collaborate-widely.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: 3-collaborez-largement
 ---
-# 3. Collaborate widely (draft)
-
-{: property="name" #wb-cont}
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/4-empower-staff-deliver-better-services.md
+++ b/en/4-empower-staff-deliver-better-services.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: 4-habiliter-personnel-fournir-meilleurs-services
 ---
-# 4. Empower staff to deliver better services (draft){: property="name" #wb-cont}
+# 4. Empower staff to deliver better services (draft)
+
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/4-empower-staff-deliver-better-services.md
+++ b/en/4-empower-staff-deliver-better-services.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: 4-habiliter-personnel-fournir-meilleurs-services
 ---
-# 4. Empower staff to deliver better services (draft)
-
-{: property="name" #wb-cont}
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/5-work-in-open-by-default.md
+++ b/en/5-work-in-open-by-default.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: 5-travailler-air-libre-par-defaut
 ---
-# 5. Work in the open by default (draft)
-
-{: property="name" #wb-cont}
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/5-work-in-open-by-default.md
+++ b/en/5-work-in-open-by-default.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: 5-travailler-air-libre-par-defaut
 ---
-# 5. Work in the open by default (draft){: property="name" #wb-cont}
+# 5. Work in the open by default (draft)
+
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/6-use-open-standards-solutions.md
+++ b/en/6-use-open-standards-solutions.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: 6-utiliser-standards-solutions-ouverts
 ---
-# 6. Use open standards and solutions (draft){: property="name" #wb-cont}
+# 6. Use open standards and solutions (draft)
+
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/6-use-open-standards-solutions.md
+++ b/en/6-use-open-standards-solutions.md
@@ -1,14 +1,10 @@
 ---
 layout: default
-title:  ". Use open standards and solutions (draft)"
+title:  "6. Use open standards and solutions (draft)"
 lang: en
 altLang: fr
 altLangPage: 6-utiliser-standards-solutions-ouverts
 ---
-# 6. Use open standards and solutions (draft)
-
-{: property="name" #wb-cont}
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/7-iterate-improve-frequently.md
+++ b/en/7-iterate-improve-frequently.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: 7-iterer-ameliorer-frequemment
 ---
-# 7. Iterate and improve frequently (draft){: property="name" #wb-cont}
+# 7. Iterate and improve frequently (draft)
+
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/7-iterate-improve-frequently.md
+++ b/en/7-iterate-improve-frequently.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: 7-iterer-ameliorer-frequemment
 ---
-# 7. Iterate and improve frequently (draft)
-
-{: property="name" #wb-cont}
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/8-design-ethical-services.md
+++ b/en/8-design-ethical-services.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: 8-concevoir-services-ethiques
 ---
-# 8. Design ethical services (draft)
-
-{: property="name" #wb-cont}
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/8-design-ethical-services.md
+++ b/en/8-design-ethical-services.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: 8-concevoir-services-ethiques
 ---
-# 8. Design ethical services (draft){: property="name" #wb-cont}
+# 8. Design ethical services (draft)
+
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/9-address-security-privacy-risks.md
+++ b/en/9-address-security-privacy-risks.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: 9-aborder-risques-securite-confidentialite
 ---
-# 9. Address security and privacy risks (draft)
-
-{: property="name" #wb-cont}
-
 **[TODO: Add/revise introductory text]**
 
 **Guidelines:**

--- a/en/9-address-security-privacy-risks.md
+++ b/en/9-address-security-privacy-risks.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: 9-aborder-risques-securite-confidentialite
 ---
-# 9. Address security and privacy risks (draft){: property="name" #wb-cont}
+# 9. Address security and privacy risks (draft)
+
+{: property="name" #wb-cont}
 
 **[TODO: Add/revise introductory text]**
 

--- a/en/comparison-tables.md
+++ b/en/comparison-tables.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: apercu
 ---
-# Comparison tables (draft)
-
-{: property="name" #wb-cont}
-
 1. [Government of Canada Digital Playbook comparison table](#government-of-canada-digital-playbook-comparison-table)
 1. **TODO:** Digital Service Standard (UK) comparison table
 1. **TODO:** Digital Service Standard (Ontario) comparison table

--- a/en/comparison-tables.md
+++ b/en/comparison-tables.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: apercu
 ---
-# Comparison tables (draft){: property="name" #wb-cont}
+# Comparison tables (draft)
+
+{: property="name" #wb-cont}
 
 1. [Government of Canada Digital Playbook comparison table](#government-of-canada-digital-playbook-comparison-table)
 1. **TODO:** Digital Service Standard (UK) comparison table

--- a/en/overview.md
+++ b/en/overview.md
@@ -5,10 +5,6 @@ lang: en
 altLang: fr
 altLangPage: apercu
 ---
-# Government of Canada Digital Playbook (draft)
-
-{: property="name" #wb-cont}
-
 ## Overview (draft)
 
 ### Structure of this document (draft)

--- a/en/overview.md
+++ b/en/overview.md
@@ -5,6 +5,7 @@ lang: en
 altLang: fr
 altLangPage: apercu
 ---
+
 ## Overview (draft)
 
 ### Structure of this document (draft)

--- a/en/overview.md
+++ b/en/overview.md
@@ -5,7 +5,9 @@ lang: en
 altLang: fr
 altLangPage: apercu
 ---
-# Government of Canada Digital Playbook (draft){: property="name" #wb-cont}
+# Government of Canada Digital Playbook (draft)
+
+{: property="name" #wb-cont}
 
 ## Overview (draft)
 

--- a/fr/1-concevoir-avec-utilisateurs.md
+++ b/fr/1-concevoir-avec-utilisateurs.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 1-design-with-users
 ---
-# 1. Concevoir avec les utilisateurs (ébauche){: property="name" #wb-cont}
+# 1. Concevoir avec les utilisateurs (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/1-concevoir-avec-utilisateurs.md
+++ b/fr/1-concevoir-avec-utilisateurs.md
@@ -1,14 +1,10 @@
 ---
 layout: default
-title:  "Concevoir avec les utilisateurs (ébauche)"
+title:  "1. Concevoir avec les utilisateurs (ébauche)"
 lang: fr
 altLang: en
 altLangPage: 1-design-with-users
 ---
-# 1. Concevoir avec les utilisateurs (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/10-soyez-bons-gestionnaires-donnees.md
+++ b/fr/10-soyez-bons-gestionnaires-donnees.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 10-be-good-data-stewards
 ---
-# 10. Soyez de bons gestionnaires de données (ébauche){: property="name" #wb-cont}
+# 10. Soyez de bons gestionnaires de données (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/10-soyez-bons-gestionnaires-donnees.md
+++ b/fr/10-soyez-bons-gestionnaires-donnees.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: 10-be-good-data-stewards
 ---
-# 10. Soyez de bons gestionnaires de données (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/2-construire-dans-accessibilite-des-debut.md
+++ b/fr/2-construire-dans-accessibilite-des-debut.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: 2-build-in-accessibility-from-start
 ---
-# 2. Construire dans l'accessibilité dès le début (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/2-construire-dans-accessibilite-des-debut.md
+++ b/fr/2-construire-dans-accessibilite-des-debut.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 2-build-in-accessibility-from-start
 ---
-# 2. Construire dans l'accessibilité dès le début (ébauche){: property="name" #wb-cont}
+# 2. Construire dans l'accessibilité dès le début (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/3-collaborez-largement.md
+++ b/fr/3-collaborez-largement.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 3-collaborate-widely
 ---
-# 3. Collaborez largement (ébauche){: property="name" #wb-cont}
+# 3. Collaborez largement (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/3-collaborez-largement.md
+++ b/fr/3-collaborez-largement.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: 3-collaborate-widely
 ---
-# 3. Collaborez largement (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/4-habiliter-personnel-fournir-meilleurs-services.md
+++ b/fr/4-habiliter-personnel-fournir-meilleurs-services.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: 4-empower-staff-deliver-better-services
 ---
-# 4. Habiliter le personnel à fournir de meilleurs services (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/4-habiliter-personnel-fournir-meilleurs-services.md
+++ b/fr/4-habiliter-personnel-fournir-meilleurs-services.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 4-empower-staff-deliver-better-services
 ---
-# 4. Habiliter le personnel à fournir de meilleurs services (ébauche){: property="name" #wb-cont}
+# 4. Habiliter le personnel à fournir de meilleurs services (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/5-travailler-air-libre-par-defaut.md
+++ b/fr/5-travailler-air-libre-par-defaut.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 5-work-in-open-by-default
 ---
-# 5. Travailler à l'air libre par défaut (ébauche){: property="name" #wb-cont}
+# 5. Travailler à l'air libre par défaut (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/5-travailler-air-libre-par-defaut.md
+++ b/fr/5-travailler-air-libre-par-defaut.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: 5-work-in-open-by-default
 ---
-# 5. Travailler à l'air libre par défaut (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/6-utiliser-standards-solutions-ouverts.md
+++ b/fr/6-utiliser-standards-solutions-ouverts.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 6-use-open-standards-solutions
 ---
-# 6. Utiliser des standards et solutions ouverts (ébauche){: property="name" #wb-cont}
+# 6. Utiliser des standards et solutions ouverts (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/6-utiliser-standards-solutions-ouverts.md
+++ b/fr/6-utiliser-standards-solutions-ouverts.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: 6-use-open-standards-solutions
 ---
-# 6. Utiliser des standards et solutions ouverts (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/7-iterer-ameliorer-frequemment.md
+++ b/fr/7-iterer-ameliorer-frequemment.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 7-iterate-improve-frequently
 ---
-# 7. Itérer et améliorer fréquemment (ébauche){: property="name" #wb-cont}
+# 7. Itérer et améliorer fréquemment (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/7-iterer-ameliorer-frequemment.md
+++ b/fr/7-iterer-ameliorer-frequemment.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: 7-iterate-improve-frequently
 ---
-# 7. Itérer et améliorer fréquemment (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/8-concevoir-services-ethiques.md
+++ b/fr/8-concevoir-services-ethiques.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: 8-design-ethical-services
 ---
-# 8. Concevoir des services éthiques (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/8-concevoir-services-ethiques.md
+++ b/fr/8-concevoir-services-ethiques.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 8-design-ethical-services
 ---
-# 8. Concevoir des services éthiques (ébauche){: property="name" #wb-cont}
+# 8. Concevoir des services éthiques (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/9-aborder-risques-securite-confidentialite.md
+++ b/fr/9-aborder-risques-securite-confidentialite.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: 9-address-security-privacy-risks
 ---
-# 9. Aborder les risques de sécurité et de confidentialité (ébauche){: property="name" #wb-cont}
+# 9. Aborder les risques de sécurité et de confidentialité (ébauche)
+
+{: property="name" #wb-cont}
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 

--- a/fr/9-aborder-risques-securite-confidentialite.md
+++ b/fr/9-aborder-risques-securite-confidentialite.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: 9-address-security-privacy-risks
 ---
-# 9. Aborder les risques de sécurité et de confidentialité (ébauche)
-
-{: property="name" #wb-cont}
-
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Lignes directrices :**

--- a/fr/apercu.md
+++ b/fr/apercu.md
@@ -5,10 +5,6 @@ lang: fr
 altLang: en
 altLangPage: overview
 ---
-# Guide numérique du gouvernement du Canada (ébauche)
-
-{: property="name" #wb-cont}
-
 ## Aperçu (ébauche)
 
 ### Structure de ce document (ébauche)

--- a/fr/apercu.md
+++ b/fr/apercu.md
@@ -5,6 +5,7 @@ lang: fr
 altLang: en
 altLangPage: overview
 ---
+
 ## Aperçu (ébauche)
 
 ### Structure de ce document (ébauche)

--- a/fr/apercu.md
+++ b/fr/apercu.md
@@ -5,7 +5,9 @@ lang: fr
 altLang: en
 altLangPage: overview
 ---
-# Guide numérique du gouvernement du Canada (ébauche){: property="name" #wb-cont}
+# Guide numérique du gouvernement du Canada (ébauche)
+
+{: property="name" #wb-cont}
 
 ## Aperçu (ébauche)
 


### PR DESCRIPTION
* Avoids  duplication and addresses the conflict between Kramdown wanting the properties on the next line after a header and markdownlint wanting a blank after the header (without disabling the check inline).
* Disabled 'MD002 - First header should be a top level header' and 'MD041 - First header should be a top level header' since h1 is being added externally through an include (which triggers errors if these checks aren't disabled)