### PR TITLE
Removed wiki.ic.gc.ca link check exclusion

### DIFF
--- a/link-check.js
+++ b/link-check.js
@@ -9,7 +9,7 @@ var path = require("path");
 var url = require("url");
 var chalk = require("chalk");
 
-var internalGCHosts = ["www.gcpedia.gc.ca", "wiki.ic.gc.ca"]
+var internalGCHosts = ["www.gcpedia.gc.ca"]
 var files = glob.sync("**/*.md", {ignore: "node_modules/**/*.md"})
 
 var deads = false;


### PR DESCRIPTION
* No longer needed since the wiki.ic.gc.ca link was removed in PR #72.
* Fixes #70 