### PR TITLE
Added missing French content and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 - [Aperçu](fr/apercu.md)
 - [1. Concevoir avec les utilisateurs](fr/1-concevoir-avec-utilisateurs.md)
 - [2. Construire dans l'accessibilité dès le début](fr/2-construire-dans-accessibilite-des-debut.md)
-- [3. Collaborez](fr/3-collaborez-largement.md)
+- [3. Collaborez largement](fr/3-collaborez-largement.md)
 - [4. Habiliter le personnel à fournir des meilleurs services](fr/4-habiliter-personnel-fournir-meilleurs-services.md)
 - [5. Travailler à l'air libre par défaut](fr/5-travailler-air-libre-par-defaut.md)
 - [6. Utiliser des standards et solutions ouverts](fr/6-utiliser-standards-solutions-ouverts.md)

--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ SkipToMain:
   fr: Passer au contenu principal
 SkipToAbout:
   en: Skip to "About this site"
-  fr: Passer à «&#160;Au sujet du gouvernement&#160;»
+  fr: Passer à «&#160;À propos de ce site&#160;»
 LanguageSelection:
   en: Language selection
   fr: Sélection de la langue
@@ -183,7 +183,7 @@ FooterSection1Item9URL:
   fr: http://ouvert.canada.ca/
 FooterSection2:
   en: About this site
-  fr:
+  fr: À propos de ce site
 FooterSection2Item1:
   en: Social media
   fr: Médias sociaux

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,7 @@
 <!-- Meta data-->
 <!-- Load closure template scripts -->
 <script type="text/javascript" src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/cdts/compiled/soyutils.js"></script>
-<script type="text/javascript" src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/cdts/compiled/wet-en.js"></script>
+<script type="text/javascript" src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/cdts/compiled/wet-{{ page.lang }}.js"></script>
 
 <noscript>
 <!-- Write closure fall-back static file -->

--- a/en/1-design-with-users.md
+++ b/en/1-design-with-users.md
@@ -419,6 +419,7 @@ We need to understand the different ways people will interact with our services,
 **[TODO: Add/revise implementation guide items]**
 
 </section>
+
 <section markdown="1" class="dpgn-section-similar">
 
 ### Similar resources

--- a/en/10-be-good-data-stewards.md
+++ b/en/10-be-good-data-stewards.md
@@ -348,6 +348,19 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 **[TODO: Add/revise implementation guide items]**
 
+- [Preserving digital collections (The National Archives (UK))](https://www.nationalarchives.gov.uk/archives-sector/advice-and-guidance/managing-your-collection/preserving-digital-collections/)
+  - [How to get started (Preserving digital collections (The National Archives (UK)))](https://www.nationalarchives.gov.uk/archives-sector/advice-and-guidance/managing-your-collection/preserving-digital-collections/how-to-get-started/)
+
+  - [Developing a digital preservation strategy and policy (Preserving digital collections (The National Archives (UK)))](https://www.nationalarchives.gov.uk/archives-sector/advice-and-guidance/managing-your-collection/preserving-digital-collections/developing-a-digital-preservation-strategy-and-policy/)
+
+  - [Digital preservation tools (Preserving digital collections (The National Archives (UK)))](https://www.nationalarchives.gov.uk/archives-sector/advice-and-guidance/managing-your-collection/preserving-digital-collections/digital-preservation-tools/)
+
+- [Sustainability of Digital Formats: Planning for Library of Congress Collections (US)](https://www.loc.gov/preservation/digital/formats/index.html)
+
+  - [Formats, Evluation Factors and Relationships (Sustainability of Digital Formats: Planning for Library of Congress Collections (US))](https://www.loc.gov/preservation/digital/formats/intro/format_eval_rel.shtml)
+
+  - [Sustainability Factors (Sustainability of Digital Formats: Planning for Library of Congress Collections (US))](https://www.loc.gov/preservation/digital/formats/sustain/sustain.shtml)
+
 </section>
 </section>
 

--- a/en/3-collaborate-widely.md
+++ b/en/3-collaborate-widely.md
@@ -43,6 +43,8 @@ altLangPage: 3-collaborez-largement
 
 ## 3.1 Empower multidisciplinary teams with diverse perspectives and skills
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **[TODO: Add/revise introductory text]**
 
 Put in place a sustainable multidisciplinary team that can design, build and continuously improve the digital service, led by a skilled product manager who is empowered to make decisions.

--- a/en/8-design-ethical-services.md
+++ b/en/8-design-ethical-services.md
@@ -75,7 +75,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 ### Checklist
 
-- **[TODO: Add/revise checklist items]**
+**[TODO: Add/revise checklist items]**
 
 </section>
 
@@ -83,7 +83,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 ### Implementation guides
 
-- **[TODO: Add/revise implementation guide items]**
+**[TODO: Add/revise implementation guide items]**
 
 </section>
 </section>
@@ -102,7 +102,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 ### Checklist
 
-- **[TODO: Add/revise checklist items]**
+**[TODO: Add/revise checklist items]**
 
 </section>
 
@@ -110,7 +110,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 ### Implementation guides
 
-- **[TODO: Add/revise implementation guide items]**
+**[TODO: Add/revise implementation guide items]**
 
 </section>
 </section>
@@ -129,7 +129,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 ### Checklist
 
-- **[TODO: Add/revise checklist items]**
+**[TODO: Add/revise checklist items]**
 
 </section>
 
@@ -137,7 +137,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 ### Implementation guides
 
-- **[TODO: Add/revise implementation guide items]**
+**[TODO: Add/revise implementation guide items]**
 
 </section>
 </section>
@@ -156,7 +156,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 ### Checklist
 
-- **[TODO: Add/revise checklist items]**
+**[TODO: Add/revise checklist items]**
 
 </section>
 
@@ -164,7 +164,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 ### Implementation guides
 
-- **[TODO: Add/revise implementation guide items]**
+**[TODO: Add/revise implementation guide items]**
 
 </section>
 </section>

--- a/fr/1-concevoir-avec-utilisateurs.md
+++ b/fr/1-concevoir-avec-utilisateurs.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 1-design-with-users
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -24,6 +30,10 @@ altLangPage: 1-design-with-users
 [1.7 Rendre plus pratique et pratique l'utilisation des services numériques](#user-content-17-rendre-plus-pratique-et-pratique-lutilisation-des-services-numériques)
 
 [1.8 Soutenir les personnes qui ne peuvent pas utiliser les services numériques par leurs propres moyens](#user-content-18-soutenir-les-personnes-qui-ne-peuvent-pas-utiliser-les-services-numériques-par-leurs-propres-moyens)
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
@@ -49,11 +59,21 @@ altLangPage: 1-design-with-users
 
 [10.1 Collecter les données une fois pour éviter la duplication (Norme&#160;10&#160;: Soyez de bons gestionnaires de données)](10-soyez-bons-gestionnaires-donnees.md#user-content-101-collecter-les-données-une-fois-pour-éviter-la-duplication)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 1.1 Construire rien pour l'utilisateur, sans que l'utilisateur soit impliqué
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 Concentrez-vous sur les besoins de vos utilisateurs, en utilisant des méthodes agiles, itératives et centrées sur l'utilisateur lors de la construction d'un service. Commencez par une recherche et une analyse approfondies pour vous aider à comprendre qui utilise le service, quels sont ses besoins et comment le service affectera sa vie pour mieux comprendre comment le service devrait être conçu. L'absence de la voix de l'utilisateur conduit à des hypothèses qui peuvent être incorrectes et coûteuses.
 
 Les utilisateurs doivent être impliqués tout au long du cycle de vie du service, les recherches et les tests des utilisateurs informant les premières phases de la conception jusqu'à des améliorations continues après le lancement du service.
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -77,21 +97,42 @@ Les utilisateurs doivent être impliqués tout au long du cycle de vie du servic
 
 - Fournir un mécanisme aux utilisateurs permettant de recevoir une rétroaction et de régler en temps opportun les problèmes de services (comme l'exige la [Politique sur les services](https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=27916#cha7))
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'application
 
 **[TODO: Ajouter / réviser les éléments du guide de mise en œuvre]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
 
 ### Ressources similaires
 
 - [2. Let client data lead: act on and adapt to feedback (Think - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Think#2._Let_client_data_lead:_act_on_and_adapt_to_feedback)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est important de planifier la recherche continue des utilisateurs et les tests d'utilisabilité. Impliquer les utilisateurs à toutes les étapes, en recherchant continuellement des commentaires pour s'assurer que le service aide les utilisateurs à accomplir leurs tâches et continuer à améliorer le service pour mieux répondre aux besoins des utilisateurs.
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -102,6 +143,10 @@ Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est import
 - carry out research and usability tests regularly and use the results to improve the design of your service **(Digital Service Standard (UK))**
 
 - develop a user research plan for private beta and a plan for carrying out user research on the live service **(Digital Service Standard (UK))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Stages bêta et en direct
 
@@ -121,17 +166,35 @@ Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est import
 
 - document any problems you haven't been able to solve in beta and how you'll handle them in public beta **(Digital Service Standard (UK))**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'application
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
 
 ### Ressources similaires
 
 - [2. Do ongoing user research (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/do-ongoing-user-research)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 1.3 Comprendre le contexte dans lequel les gens interagissent et conçoivent des solutions adaptées à leurs besoins
 
 Un élément clé du développement de services numériques qui fonctionnent pour les utilisateurs consiste à bien comprendre qui sont les utilisateurs, quels sont leurs besoins et comment le service affectera leur vie. Il est également important de développer une bonne compréhension des différents contextes dans lesquels les utilisateurs peuvent interagir, car les besoins et les attentes des utilisateurs peuvent varier en fonction du lieu, du moment et de la manière dont ils utilisent un service numérique.
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -139,6 +202,8 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 
 - Clearly defined user needs **(Build It Right - OneGC Architectural Checklist (draft))**
   - User research, requirements and usability testing must be incorporated and tracked from the very beginning of any digital project
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -163,6 +228,10 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 - **What are the user needs?** What are the opportunities to remove or reduce the pain points? How might we better meet the user needs? (Demonstrate this through research, testing and validating possible solutions with prototypes) **(Digital Service Standard (AU))**
 
 - **Are you designing the right thing?** How have your insights from user research helped you to define your minimum viable product (MVP)? How does the MVP create value for users and government by better meeting user needs? **(Digital Service Standard (AU))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -194,6 +263,10 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 
 - **How will you know if your design is working?** Make sure that research has fed into the metrics you have developed to know that you continue to meet your user needs **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+
 #### Stage en direct
 
 - Use research and testing results to continuously improve the service **(Digital Service Standard (Ontario))**
@@ -205,6 +278,11 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 - **Show how you are using data from real use** to understand which parts of the task users are finding difficult and how you are designing experiments to reduce friction and increase success for users **(Digital Service Standard (AU))**
 
 - Know how you will measure and monitor your service to ensure it is serving its users well **(Digital Service Standard (AU))**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'application
 
@@ -246,6 +324,10 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 
 - [Evangelising user research](https://medium.com/@userfocus/evangelising-user-research-849430701b6e) **(David Travis (Medium.com))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [1. Understand user needs (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/understand-user-needs)
@@ -258,11 +340,22 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 
 - [1. Understand client needs (Think - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Think#1._Understand_client_needs)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 1.4 Clairement articuler and understand the problem of about and use the data for evidence
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 We need to understand the different ways people will interact with our services, including the actions they take online, through a mobile application, on a phone, or in person. Every encounter --- whether it's online or offline --- should move the user closer towards their goal. **(Digital Services Playbook (US))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -276,17 +369,36 @@ We need to understand the different ways people will interact with our services,
 
 - Develop metrics that will measure how well the service is meeting user needs at each step of the service **(Digital Services Playbook (US))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'application
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
 
 ### Ressources similaires
 
 - [2. Address the whole experience, from start to finish (Digital Services Playbook (US))](https://playbook.cio.gov/#play2)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline dpgn-phase-alpha">
+
 ## 1.5 Fournir des services qui peuvent être tout, quand et n'importe quel appareil
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -297,15 +409,30 @@ We need to understand the different ways people will interact with our services,
 - Platform agnostic **(Build It Right - OneGC Architectural Checklist (draft))**
   - Build applications for easy deployment and portability regardless of platform/operating system by default (e.g., open standard containers)
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'application
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
 
 ### Ressources similaires
 
 - [Digital by design, optimized for mobile (General design principles - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/Digital_Design_Playbook)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 1.6 Rendre les services simples, intuitifs et cohérents
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -324,6 +451,10 @@ Consistent design that is responsive to different devices helps you to save time
 Responsive design ensures that users can interact with your service regardless of their device size or type, and browser or device processing power. The service should follow mobile-first design principles, consider users on slow internet connections or with limited download data, work well for both mouse and touch devices, and use front-end technology that works well regardless of device processing power.
 
 Writing and designing content so it is consistent, plain and in the language of your users helps people gain trust and confidence in using different services. By providing information they can easily understand they may be less likely to use alternative websites that could be misleading. **(Digital Service Standard (AU))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -371,6 +502,10 @@ Writing and designing content so it is consistent, plain and in the language of 
 
 - ensure appropriate design, content design and front-end developer support is provided to the team. **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'application
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -391,6 +526,10 @@ Writing and designing content so it is consistent, plain and in the language of 
 
 - [Government Digital Service (GDS) style guide](https://www.gov.uk/guidance/style-guide)  **(Government Digital Service (UK))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [12. Make sure users succeed first time (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/create-a-service-thats-simple)
@@ -405,7 +544,14 @@ Writing and designing content so it is consistent, plain and in the language of 
 
 - [6. Consistent and responsive design (Digital Service Standard (AU))](https://www.dta.gov.au/standard/6-consistent-and-responsive/)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 1.7 Rendre plus pratique et pratique l'utilisation des services numériques
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -437,9 +583,15 @@ We still need to help users who are unable to use digital channels and provide s
 
 **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -473,6 +625,10 @@ We still need to help users who are unable to use digital channels and provide s
 
 - show you understand how you will increase digital take-up and what targets you will set. **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+
 #### Stage bêta
 
 - Plan to increase how many people use the digital service and show the evidence **(Digital Service Standard (Ontario))**
@@ -490,6 +646,10 @@ We still need to help users who are unable to use digital channels and provide s
 - have agreed analytics/metrics for the volume of usage across channels **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
 
 - understand the full impact of retiring any potentially redundant services and channels. **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -509,6 +669,10 @@ We still need to help users who are unable to use digital channels and provide s
 
 - show how you will promote your service and encourage people to use it, including how your messaging will appear in places where the users will see it. **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+
 #### Stages bêta et en direct
 
 - detail the channels required to support all groups of users of the service **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
@@ -516,6 +680,11 @@ We still need to help users who are unable to use digital channels and provide s
 - understand the non-digital service channels and have a plan to move users to the digital channel where appropriate **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
 
 - have developed and tested the service so that a user can change channels without repeating themselves. **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -527,6 +696,10 @@ We still need to help users who are unable to use digital channels and provide s
 
 - [Assisted Digital](https://www.dta.gov.au/standard/design-guides/assisted-digital/) **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [14. Encourage everyone to use the digital service (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/encourage-everyone-to-use-the-digital-service)
@@ -537,7 +710,13 @@ We still need to help users who are unable to use digital channels and provide s
 
 - [13. Encourage everyone to use the digital service (Digital Service Standard (AU))](https://www.dta.gov.au/standard/13-encourage-use-of-the-digital-service/)
 
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 1.8 Soutenir les personnes qui ne peuvent pas utiliser les services numériques par leurs propres moyens
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -548,6 +727,10 @@ Not everyone will have the same access, comfort and skill level to use digital s
 Users may expect that an online service is available 24 hours a day, 365 days a year.
 
 You need to have a plan for what to do if your service goes offline so that you know how users will be affected and how to get it back online. **(Digital Service Standard (UK) (Make a plan for being offline))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -571,6 +754,10 @@ You need to have a plan for what to do if your service goes offline so that you 
 
 - Determine your strategy for dealing with outages, including who's responsible and the decisions they can make **(Digital Service Standard (UK))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -579,8 +766,15 @@ You need to have a plan for what to do if your service goes offline so that you 
 
 - [Assisted Digital](https://www.dta.gov.au/standard/design-guides/assisted-digital/) **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [11. Make a plan for being offline (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/make-a-plan-for-being-offline)
 
 - [12. Soutien aux personnes qui en ont besoin (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-13)
+
+</section>
+</section>

--- a/fr/10-soyez-bons-gestionnaires-donnees.md
+++ b/fr/10-soyez-bons-gestionnaires-donnees.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 10-be-good-data-stewards
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -20,6 +26,10 @@ altLangPage: 10-be-good-data-stewards
 [10.5 Assurer les données et dans la formation est complète, précise et à jour](#user-content-105-assurer-les-données-et-dans-la-formation-est-complète-précise-et-à-jour)
 
 [10.6 Assurez-vous que les données sont bien structurées, intuitives et dans un format facile à intégrer et réutiliser par d'autres](#user-content-106-assurez-vous-que-les-données-sont-bien-structurées-intuitives-et-dans-un-format-facile-à-intégrer-et-réutiliser-par-dautres)
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
@@ -41,25 +51,48 @@ altLangPage: 10-be-good-data-stewards
 
 [9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-92-innover-et-sam%C3%A9liorer-tout-en-r%C3%A9pondant-aux-attentes-du-public-quant-%C3%A0-la-protection-de-la-confidentialit%C3%A9-des-donn%C3%A9es)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 10.1 Collecter les données une fois pour éviter la duplication
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 10.2 Rendre les informations et les données gouvernementales pertinentes facilement accessibles pour aider à la prise de décision
 
-**Relatif (temporaire à des fins de cartographie, à supprimer plus tard):**
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 At every stage of a project, we should measure how well our service is working for our users. This includes measuring how well a system performs and how people are interacting with it in real-time. Our teams and agency leadership should carefully watch these metrics to find issues and identify which bug fixes and improvements should be prioritized. Along with monitoring tools, a feedback mechanism should be in place for people to report issues directly. **(Digital Services Playbook (US))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -81,6 +114,10 @@ At every stage of a project, we should measure how well our service is working f
 
 - Use an experimentation tool that supports multivariate testing in production **(Digital Services Playbook (US))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -93,11 +130,22 @@ At every stage of a project, we should measure how well our service is working f
 
   - [Real Time Access (Data on the Web Best Practices (W3C))](https://www.w3.org/TR/dwbp/#AccessRealTime)
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [12. Use data to drive decisions (Digital Services Playbook (US))](https://playbook.cio.gov/#play12)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 10.3 Assurez-vous que les données sont collectées de manière standard afin qu'elles puissent être facilement intégrées et réutilisées par d'autres
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -125,9 +173,15 @@ Measuring performance means continuously improving a service by:
 
 Every service must aim for continuous improvement. Metrics are an important starting point for discussions about a service’s strengths and weaknesses. By identifying and capturing the right metrics - with the right tools - you can make sure all your decisions to improve the service are supported by data.
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Stages alpha, bêta et en direct
 
@@ -159,6 +213,10 @@ Every service must aim for continuous improvement. Metrics are an important star
   - costs, benefits and return on investment
   - content metrics (readability, length).
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+
 #### Stage alpha
 
 - explored the data that is already available for an existing service, where it is kept and how you might access and use it, and also shared your own insights **(Digital Service Standard (AU))**
@@ -170,6 +228,10 @@ Every service must aim for continuous improvement. Metrics are an important star
 - started creating a performance framework outlining your objectives and what metrics your team will use to demonstrate you meet them **(Digital Service Standard (AU))**
 
 - considered the metrics you will need to measure the 4 KPIs and where the data will come from. **(Digital Service Standard (AU))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -184,6 +246,10 @@ Every service must aim for continuous improvement. Metrics are an important star
 - which tools you use for analysis and web analytics in Beta (and Alpha if appropriate) **(Digital Service Standard (AU))**
 
 - what you have learned from qualitative and quantitative data; for example key evidence. **(Digital Service Standard (AU))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -214,6 +280,11 @@ Every service must aim for continuous improvement. Metrics are an important star
   - completion rate has been maintained
   - cost per transaction is decreasing in line with service plans.
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -238,6 +309,10 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 - [Measuring success](https://www.gov.uk/service-manual/measuring-success) **(Service manual (UK))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [15. Collect performance data (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/collect-performance-data)
@@ -246,13 +321,28 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 - [11. Measure performance (Digital Service Standard (AU))](https://www.dta.gov.au/standard/11-measure-performance/)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 10.4 Tenir dûment compte de la conservation et de la conservation numériques
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -271,9 +361,20 @@ Every service must aim for continuous improvement. Metrics are an important star
 
   - [Sustainability Factors (Sustainability of Digital Formats: Planning for Library of Congress Collections (US))](https://www.loc.gov/preservation/digital/formats/sustain/sustain.shtml)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 10.5 Assurer les données et dans la formation est complète, précise et à jour
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -283,13 +384,28 @@ Every service must aim for continuous improvement. Metrics are an important star
   - Make certain that data is complete, authoritative, accurate, and timely to ensure a high level of data quality
   - Ensure data is able to be shared and can be easily accessed
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 10.6 Assurez-vous que les données sont bien structurées, intuitives et dans un format facile à intégrer et réutiliser par d'autres
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -301,6 +417,13 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 - Design data with a consistent and precise naming convention. Use plain language and recognizable patterns and concepts, avoiding abbreviations where possible.
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+</section>

--- a/fr/2-construire-dans-accessibilite-des-debut.md
+++ b/fr/2-construire-dans-accessibilite-des-debut.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 2-build-in-accessibility-from-start
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -16,6 +22,10 @@ altLangPage: 2-build-in-accessibility-from-start
 [2.3 Co-créer avec des personnes ayant des besoins distincts, en étant inclusif dès le début](#user-content-23-co-créer-avec-des-personnes-ayant-des-besoins-distincts-en-étant-inclusif-dès-le-début)
 
 [2.4 Prendre en compte les contraintes possibles d'un utilisateur lors de la conception de services](#user-content-24-prendre-en-compte-les-contraintes-possibles-dun-utilisateur-lors-de-la-conception-de-services)
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
@@ -33,12 +43,22 @@ altLangPage: 2-build-in-accessibility-from-start
 
 [8.4 Équilibrer les compromis entre innovation et inclusivité (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-84-%C3%89quilibrer-les-compromis-entre-innovation-et-inclusivit%C3%A9)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 2.1 Construire pour ceux qui ont les plus grands besoins et cela fonctionnera pour tout le monde
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 Le gouvernement du Canada est déterminé à faire en sorte qu'un niveau
 élevé d'accessibilité soit uniformément appliqué à tous ses canaux de prestation de services. Les technologies et les normes évoluent constamment et l'accessibilité joue un rôle majeur pour rendre le gouvernement du Canada plus efficace et inclusif. Une plus cohérente, pratique, clair et facile utilisateur expérience lors de l'utilisation des services gouvernementaux en ligne construit la confiance.
 
 Le développement de services numériques accessibles (indépendamment de la capacité, de l'appareil ou de l'environnement) améliore l'expérience globale pour tout le monde en améliorant et en simplifiant la conception globale.
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -57,6 +77,10 @@ Le développement de services numériques accessibles (indépendamment de la cap
 - Faites en sorte qu'il soit facile pour tous les utilisateurs (y compris les personnes handicapées) de fournir des commentaires, de résoudre les problèmes et de demander de l'aide pour utiliser le service.
 
 - Utilisez des recherches, des tests et des analyses en continu pour évaluer et améliorer continuellement l'accessibilité du service.
+
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -81,7 +105,14 @@ Le développement de services numériques accessibles (indépendamment de la cap
   - [Orientation sur la mise en œuvre de la Norme sur l’accessibilité des sites Web](http://tbs-sct.gc.ca/ws-nw/wa-aw/wa-aw-guid-fra.asp)
 - [A checklist for digital inclusion - if we do these things, we’re doing digital inclusion (Government Digital Service Blog (UK))](https://gds.blog.gov.uk/2014/01/13/a-checklist-for-digital-inclusion-if-we-do-these-things-were-doing-digital-inclusion/)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 2.2 Les services devraient respecter ou dépasser les normes d'accessibilité, et ne devraient pas être pénibles à utiliser
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -98,6 +129,10 @@ Ensure the service is accessible to all users regardless of their ability and en
 You need to make sure everyone who needs your service can use it. This includes people with disabilities and older people, and people who can’t use, or struggle with, digital services.
 
 Your service must be accessible to users regardless of their digital confidence and access to a digital environment. This includes users in remote areas and users’ different devices. **(Digital Service Standard (AU))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -127,6 +162,8 @@ Your service must be accessible to users regardless of their digital confidence 
 
 - make sure your staff will be equipped with knowledge of barriers to accessibility and will be trained to assist users with disabilities in completing tasks and accessing information **(Digital Service Standard (Ontario))**
 
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+
 #### Stage alpha
 
 - show the type of environments users may access the service in, including with different browsers and desktop and mobile devices, and when connections are slower and there may be limited data; for example, through user stories **(Digital Service Standard (AU))**
@@ -144,6 +181,10 @@ Your service must be accessible to users regardless of their digital confidence 
 - show any accessibility issues and barriers that might need addressing in the Beta stage **(Digital Service Standard (AU))**
 
 - show you have access to facilities to perform testing on various devices or platforms, for example a plan for testing. **(Digital Service Standard (AU))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -177,6 +218,10 @@ Your service must be accessible to users regardless of their digital confidence 
 
 - show the majority of users can access the service in their environment. **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+
 #### Stage en direct
 
 - show your service is accessible **(Digital Service Standard (AU))**
@@ -189,6 +234,11 @@ Your service must be accessible to users regardless of their digital confidence 
 - a run through of how you’ve designed and tested for users of assistive technologies based on user research, usability testing and analytics **(Digital Service Standard (AU))**
 
 - show ongoing testing plans for accessibility so that your users can continue to access the service. **(Digital Service Standard (AU))**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -215,11 +265,20 @@ Your service must be accessible to users regardless of their digital confidence 
 - [The A11y Project](https://a11yproject.com/)
 - [Making your service accessible](https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction) **(Service Manual (UK))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [7. Rendre le service accessible (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-8)
 
 - [9. Make it accessible (Digital Service Standard (AU))](https://www.dta.gov.au/standard/9-make-it-accessible/)
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
 
 ## 2.3 Co-créer avec des personnes ayant des besoins distincts, en étant inclusif dès le début
 
@@ -238,6 +297,10 @@ This applies when designing and developing:
 - Web technologies and technical specifications, such as HTML
 
 **([Involving Users in Web Projects for Better, Easier Accessibility](https://www.w3.org/WAI/users/involving))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -290,6 +353,10 @@ For websites and web applications, using comprehensive standards such as Web Con
 For authoring tools such as content management systems (CMS), blog software, and WYSIWYG editors, follow Authoring Tool Accessibility Guidelines (ATAG).
 For browsers, media players, and other 'user agents', follow User Agent Accessibility Guidelines (UAAG).
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -315,7 +382,14 @@ For browsers, media players, and other 'user agents', follow User Agent Accessib
 - [Web Experience Toolkit (WET)](https://wet-boew.github.io/v4.0-ci/index-en.html)
 - [A checklist for digital inclusion - if we do these things, we’re doing digital inclusion (Government Digital Service Blog (UK))](https://gds.blog.gov.uk/2014/01/13/a-checklist-for-digital-inclusion-if-we-do-these-things-were-doing-digital-inclusion/)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 2.4 Prendre en compte les contraintes possibles d'un utilisateur lors de la conception de services
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -326,6 +400,10 @@ Very few people are like this, especially when you take into account that a pers
 Until you consider the needs of the range of people that will be using your service you can’t confirm that you are not excluding people. You also won’t be making the cost savings that digital services can provide as you will be forcing some people to use more expensive alternate channels.
 
 [Consider the range of people that will use your product or service, Accessibility: the GDS blog](https://accessibility.blog.gov.uk/2016/05/16/consider-the-range-of-people-that-will-use-your-product-or-service/)
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -422,6 +500,10 @@ Until you consider the needs of the range of people that will be using your serv
   - rely on accurate spelling - use autocorrect or provide suggestions
   - put too much information in one place
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -444,3 +526,6 @@ Until you consider the needs of the range of people that will be using your serv
 - [Norme sur l'accessibilité des sites Web](https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=23601)
   - [Orientation sur la mise en œuvre de la Norme sur l’accessibilité des sites Web](http://tbs-sct.gc.ca/ws-nw/wa-aw/wa-aw-guid-fra.asp)
 - [A checklist for digital inclusion - if we do these things, we’re doing digital inclusion (Government Digital Service Blog (UK))](https://gds.blog.gov.uk/2014/01/13/a-checklist-for-digital-inclusion-if-we-do-these-things-were-doing-digital-inclusion/)
+
+</section>
+</section>

--- a/fr/3-collaborez-largement.md
+++ b/fr/3-collaborez-largement.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 3-collaborate-widely
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -17,6 +23,10 @@ altLangPage: 3-collaborate-widely
 
 [3.4 Partager et collaborer à l'extérieur, établir un lien avec le travail des autres et fournir des ressources que d'autres peuvent réutiliser](#user-content-34-partager-et-collaborer-à-lextérieur-établir-un-lien-avec-le-travail-des-autres-et-fournir-des-ressources-que-dautres-peuvent-réutiliser)
 
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
+
 **Lignes directrices connexes :**
 
 [1.1 Construire rien pour l'utilisateur, sans que l'utilisateur soit impliqué (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-11-construire-rien-pour-lutilisateur-sans-que-lutilisateur-soit-impliqu%C3%A9)
@@ -27,7 +37,13 @@ altLangPage: 3-collaborate-widely
 
 [5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-55-travailler-%C3%A0-lair-libre-et-rendre-le-code-source-ouvert-et-r%C3%A9utilisable)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 3.1 Habiliter des équipes multidisciplinaires avec des perspectives et des compétences diverses
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -54,6 +70,10 @@ Good government services are built quickly and iteratively, based on user needs.
 - to be adequately resourced and empowered to deliver the product or service.
 
 **(Digital Service Standard (AU))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -119,6 +139,10 @@ Good government services are built quickly and iteratively, based on user needs.
 
 - explain your plan to transfer knowledge and skills from any external people who work with the team. **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -133,6 +157,10 @@ Good government services are built quickly and iteratively, based on user needs.
 
 - [The teams, they are a changin’](https://18f.gsa.gov/2016/04/18/the-teams-they-are-a-changin/) **(18F (US))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [3. Have a multidisciplinary team (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/have-a-multidisciplinary-team)
@@ -143,9 +171,20 @@ Good government services are built quickly and iteratively, based on user needs.
 
 - [2. Have a multidisciplinary team (Digital Service Standard (AU))](https://www.dta.gov.au/standard/2-multidisciplinary-team/)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 3.2 Reconnaître qu'une organisation ne peut pas avoir toutes les meilleures idées, créer des partenariats et collaborer avec un large éventail de partenaires
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -169,6 +208,10 @@ Good government services are built quickly and iteratively, based on user needs.
 - Are supports communicated and shared?
 - Is there agreement about a “product” or outcome for the collaboration?
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -184,25 +227,53 @@ Good government services are built quickly and iteratively, based on user needs.
   - [Time Well Spent](http://thegoodproject.org/collaborationtoolkit/elements-time-well-spent/)
   - [Solution Inspired](http://thegoodproject.org/collaborationtoolkit/elements-solution-inspired/)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 3.3 Renforcer la capacité à attirer dynamiquement de nouveaux partenaires pour la co-innovation
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **Very similar to guideline 5.5 (guideline 5.5 is more specific about open source)**
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 3.4 Partager et collaborer à l'extérieur, établir un lien avec le travail des autres et fournir des ressources que d'autres peuvent réutiliser
+
+<div markdown="1" class="dpgn-section-intro-guideline">
+
+**\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 **[TODO: Determine what is meant by "link to the work of other" and then add related content]**
 
-**\[TODO: Ajouter / réviser le texte d'introduction\]**
+**Very similar to guideline 5.5 (guideline 5.5 is more specific about open source)**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -218,6 +289,8 @@ Good government services are built quickly and iteratively, based on user needs.
 
 - Show your code in an open Internet source code repository and enable contributions and comments on the code
 
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+
 #### Stage alpha
 
 - Determine the licences you're using to release code during beta **(Digital Service Standard (UK))**
@@ -232,9 +305,17 @@ Good government services are built quickly and iteratively, based on user needs.
 
 - consider publishing the source code on a platform with wide adoption in the open source community, such as GitHub. **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+
 #### Stage bêta
 
 - share your code in a repository **(Digital Service Standard (AU))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -256,6 +337,11 @@ Good government services are built quickly and iteratively, based on user needs.
 
 - show how you’re handling updates and bug fixes to the code. **(Digital Service Standard (AU))**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -274,6 +360,10 @@ Good government services are built quickly and iteratively, based on user needs.
 
 - [Making source code open](https://www.dta.gov.au/blog/making-source-code-open/) **(DTA Blog (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [Open Source Code - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/4_Open_Source_Code.md)
@@ -285,3 +375,6 @@ Good government services are built quickly and iteratively, based on user needs.
 - [13. Default to open (Digital Services Playbook (US))](https://playbook.cio.gov/#play13)
 
 - [8. Make source code open (Digital Service Standard (AU))](https://www.dta.gov.au/standard/8-make-source-code-open/)
+
+</section>
+</section>

--- a/fr/4-habiliter-personnel-fournir-meilleurs-services.md
+++ b/fr/4-habiliter-personnel-fournir-meilleurs-services.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 4-empower-staff-deliver-better-services
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -18,6 +24,10 @@ altLangPage: 4-empower-staff-deliver-better-services
 [4.4 Permettre aux équipes de prendre des décisions tout au long de la conception, de la construction et du fonctionnement du service et leur permettre d'apprendre de leurs erreurs](#user-content-44-permettre-aux-équipes-de-prendre-des-décisions-tout-au-long-de-la-conception-de-la-construction-et-du-fonctionnement-du-service-et-leur-permettre-dapprendre-de-leurs-erreurs)
 
 [4.5 Rendre une personne responsable du service](#user-content-45-rendre-une-personne-responsable-du-service)
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
@@ -43,19 +53,40 @@ altLangPage: 4-empower-staff-deliver-better-services
 
 [7.4 Commencer petit et tester continuellement les conceptions et les hypothèses, en utilisant les preuves comme base de l'itération (Norme&#160;7&#160;: Itérer et améliorer fréquemment](7-iterer-ameliorer-frequemment.md#user-content-74-commencer-petit-et-tester-continuellement-les-conceptions-et-les-hypoth%C3%A8ses-en-utilisant-les-preuves-comme-base-de-lit%C3%A9ration)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 4.1 Offrir des possibilités de formation continue et d'apprentissage pour améliorer continuellement les compétences de l'équipe et du réseau élargi
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 - **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 - **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 4.2 Assurez-vous que le personnel a accès aux outils et aux technologies dont il a besoin pour innover
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -84,11 +115,17 @@ The technology you choose to build your service must help you respond quickly an
 
 **(Digital Service Standard (AU))**
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 - **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
 - Ensure the project team has a modern workplace, professional development and the IM-IT tools they need to do their jobs
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -118,6 +155,10 @@ The technology you choose to build your service must help you respond quickly an
 
 - know the initial and ongoing costs for proposed tools and systems. **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+
 #### Stage bêta
 
 - Determine how you're managing the limits placed on your service by the technology stack and development toolchain you've chosen **(Digital Service Standard (UK))**
@@ -142,6 +183,10 @@ The technology you choose to build your service must help you respond quickly an
 
 - outsource decision-making about technology only where appropriate. **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+
 #### Stage en direct
 
 - Document the tech stack changes you made during beta and why **(Digital Service Standard (UK))**
@@ -162,17 +207,31 @@ The technology you choose to build your service must help you respond quickly an
 
 - evidence or artefacts that demonstrate you achieved the objective of the criteria for the Live stage. **(Digital Service Standard (AU))**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
 - [Australian Government ICT Policies, guide and procurement](http://www.finance.gov.au/policy-guides-procurement/whole-of-government-ict-policies/)
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [6. Evaluate tools and systems (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/evaluate-tools-and-systems)
 
 - [4. Understand tools and systems (Digital Service Standard (AU))](https://www.dta.gov.au/standard/4-tools-and-systems/)
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
 
 ## 4.3 Assurez-vous que les bons systèmes et processus sont en place pour que l'équipe puisse créer
 
@@ -181,6 +240,10 @@ The technology you choose to build your service must help you respond quickly an
 To improve our chances of success when contracting out development work, we need to work with experienced budgeting and contracting officers. In cases where we use third parties to help build a service, a well-defined contract can facilitate good development practices like conducting a research and prototyping phase, refining product requirements as the service is built, evaluating open source alternatives, ensuring frequent delivery milestones, and allowing the flexibility to purchase cloud computing resources. **(Digital Services Playbook (US))**
 
 It is essential that business processes be reviewed to identify opportunities to improve service delivery. A website is not a service; it is just one channel for accessing or delivering a service. Designing new or redesigning existing digital services should also facilitate service delivery best practices (e.g., open data and joined-up services). **(Do - Digital Design Playbook (ISED))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -218,9 +281,17 @@ It is essential that business processes be reviewed to identify opportunities to
 
 - Improve the service first and consider if a policy change or update might be needed. Second, build the digital platform/website. **(Do - Digital Design Playbook (ISED))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -228,9 +299,20 @@ It is essential that business processes be reviewed to identify opportunities to
 
 - [1. Better services rather than new websites. Optimize business processes before designing technological solutions. (Do - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#1._Better_services_rather_than_new_websites._Optimize_business_processes_before_designing_technological_solutions.)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 4.4 Permettre aux équipes de prendre des décisions tout au long de la conception, de la construction et du fonctionnement du service et leur permettre d'apprendre de leurs erreurs
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -240,15 +322,44 @@ It is essential that business processes be reviewed to identify opportunities to
 
 - Mettre l'accent sur l'innovation et la durabilité
 
+- Share information:  Sharing information with employees is important because it not only helps to build trust; it gives employees important information that will allow them to make the best possible decisions in critical situations. **([6 Ways To Empower Others To Succeed, Lisa Quast, Forbes.com contributor](https://www.forbes.com/sites/lisaquast/2011/02/28/6-ways-to-empower-others-to-succeed/#3da10ac35c62))**
+
+- Create clear goals and objectives:  Be clear with your vision, goals/objectives, and roles.  This will help create the framework necessary to guide employees to make empowered decisions to keep customers happy. **([6 Ways To Empower Others To Succeed, Lisa Quast, Forbes.com contributor](https://www.forbes.com/sites/lisaquast/2011/02/28/6-ways-to-empower-others-to-succeed/#3da10ac35c62))**
+
+- Teach that it’s o.k. to make mistakes:  If you empower employees to make decisions that will help keep customers happy, then you have to be willing to allow them to make mistakes and learn from those mistakes.  Berating an employee who tried something new will only serve to keep others from trying new things. **([6 Ways To Empower Others To Succeed, Lisa Quast, Forbes.com contributor](https://www.forbes.com/sites/lisaquast/2011/02/28/6-ways-to-empower-others-to-succeed/#3da10ac35c62))**
+
+- Create an environment that celebrates both successes and failures:  Don’t just celebrate the successes, celebrate the employees who took a risk but maybe didn’t obtain the results intended but learned valuable lessons themselves and for the company. **([6 Ways To Empower Others To Succeed, Lisa Quast, Forbes.com contributor](https://www.forbes.com/sites/lisaquast/2011/02/28/6-ways-to-empower-others-to-succeed/#3da10ac35c62))**
+
+- Support a learning environment:  This is an ongoing process whereby teams look at various situations and discuss them together to determine how they might handle things differently in the future to achieve a different result.  This is really what our lives are all about...learning new things as we age, by analyzing the things we’ve done in the past. **([6 Ways To Empower Others To Succeed, Lisa Quast, Forbes.com contributor](https://www.forbes.com/sites/lisaquast/2011/02/28/6-ways-to-empower-others-to-succeed/#3da10ac35c62))**
+
+- Let teams become the hierarchy:  This occurs by slowly and carefully transferring responsibilities from managers to teams.  This can be a very scary and difficult process that takes time, training and a lot of persistence (Kinicki & Kreitner, 2008, p. 335).  It’s been my personal experience that this requires a lot of support time to the teams as they move from depending on a manager to make decisions to being autonomous. **([6 Ways To Empower Others To Succeed, Lisa Quast, Forbes.com contributor](https://www.forbes.com/sites/lisaquast/2011/02/28/6-ways-to-empower-others-to-succeed/#3da10ac35c62))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+**[TODO: Add/revise implementation guide items]**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 4.5 Rendre une personne responsable du service
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 Each service must have one person who has the authority and is responsibile for makingt business, product and technical decisions. This person is responsible for communicating the vision, making decisions in a timely fashion, managing stakeholder/vendor relationships, monitoring project health and is accountable for the success or failure of the service. This person also sets the strategy for the service, defines the features of the service, and is responsible for the service on an ongoing basis, until it is decommissioned.
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -274,10 +385,21 @@ Each service must have one person who has the authority and is responsibile for 
 
 - Includes the ability to improve the service on a frequent basis through iteration enabled by the right capacity, resources, and technical flexibility
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [6. Assign one leader and hold that person accountable (Digital Services Playbook (US))](https://playbook.cio.gov/#play6)
+
+</section>
+</section>

--- a/fr/5-travailler-air-libre-par-defaut.md
+++ b/fr/5-travailler-air-libre-par-defaut.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 5-work-in-open-by-default
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -19,6 +25,10 @@ altLangPage: 5-work-in-open-by-default
 
 [5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable](#user-content-55-travailler-à-lair-libre-et-rendre-le-code-source-ouvert-et-réutilisable)
 
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
+
 **Lignes directrices connexes :**
 
 [3.4 Partager et collaborer à l'extérieur, établir un lien avec le travail des autres et fournir des ressources que d'autres peuvent réutiliser (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-34-partager-et-collaborer-%C3%A0-lext%C3%A9rieur-%C3%A9tablir-un-lien-avec-le-travail-des-autres-et-fournir-des-ressources-que-dautres-peuvent-r%C3%A9utiliser)
@@ -31,9 +41,19 @@ altLangPage: 5-work-in-open-by-default
 
 [10.2 Rendre les informations et les données gouvernementales pertinentes facilement accessibles pour aider à la prise de décision (Norme&#160;10&#160;: Soyez de bons gestionnaires de données)](10-soyez-bons-gestionnaires-donnees.md#user-content-102-rendre-les-informations-et-les-donn%C3%A9es-gouvernementales-pertinentes-facilement-accessibles-pour-aider-%C3%A0-la-prise-de-d%C3%A9cision)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 5.1 Rendre toutes les données et informations non sensibles ouvertes au monde extérieur pour les partager et les réutiliser sous une licence ouverte
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -51,27 +71,53 @@ altLangPage: 5-work-in-open-by-default
 
 - Data and code is shared so that clients can extract/create value. **(General design principles - Digital Design Playbook (ISED))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
-
-## 5.2 Soyez transparent avec les objectifs et publiez les données de performance en temps réel
-
-**\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 - [Open Data](https://www.dta.gov.au/standard/design-guides/open-data/) **Digital Service Standard (AU)**
 
 - [Statistical Data Integration](https://www.dta.gov.au/standard/design-guides/statistical-data-integration/) **Digital Service Standard (AU)**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
+## 5.2 Soyez transparent avec les objectifs et publiez les données de performance en temps réel
+
+<div markdown="1" class="dpgn-section-intro-guideline">
+
+**\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 5.3 Mesurez et surveillez l'efficacité, la valeur et les conséquences de votre service et signalez publiquement
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -85,9 +131,15 @@ Setting performance indicators allows you to continuously improve your service b
 
 **(Digital Service Standard (UK))**
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Stages alpha, bêta et en direct
 
@@ -111,9 +163,18 @@ Setting performance indicators allows you to continuously improve your service b
 
 - make sure all stakeholders are actively involved in promoting or supporting digital delivery of the new service **(Digital Service Standard (UK))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+
 #### Stage bêta
 
 - track people moving from using the offline service to the online one **(Digital Service Standard (UK))**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -131,15 +192,30 @@ Setting performance indicators allows you to continuously improve your service b
 
 - [Performance Testing](https://www.dta.gov.au/standard/design-guides/performance-testing/) **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [16. Identify performance indicators (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/identify-performance-indicators)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 5.4 Soyez transparent sur la façon dont vous travaillez et justifiez les décisions que vous prenez
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 Share your experiences with colleagues across the Government of Canada, other levels of government, clients and service providers. Sharing experiences and best practices helps to raise the overall service quality. It helps to reduce duplication of effort and save costs. So share ideas, share intentions, share failures and learn together. **(Plan - Digital Design Playbook (ISED))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -161,9 +237,17 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 - Make it easier to share data across ISED by collecting service and client information in a consistent manner and following best practices (e.g., the business number as a common identifier and practices related to Identity Management (IDM)). **(Plan - Digital Design Playbook (ISED))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -171,7 +255,14 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 - [2. Share best practices (Plan - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Plan#2._Share_best_practices)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -197,6 +288,10 @@ Open source helps to:
 
 **(Digital Service Standard (AU))**
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
@@ -215,6 +310,8 @@ Open source helps to:
   - Actively use and contribute to open source tools and solutions
   - Develop in the open by sharing and reusing all types of code and platform configuration
 
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+
 #### Stage alpha
 
 - Determine the licences you're using to release code during beta **(Digital Service Standard (UK))**
@@ -229,9 +326,17 @@ Open source helps to:
 
 - consider publishing the source code on a platform with wide adoption in the open source community, such as GitHub. **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+
 #### Stage bêta
 
 - share your code in a repository **(Digital Service Standard (AU))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -253,6 +358,11 @@ Open source helps to:
 
 - show how you’re handling updates and bug fixes to the code. **(Digital Service Standard (AU))**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -271,6 +381,10 @@ Open source helps to:
 
 - [Making source code open](https://www.dta.gov.au/blog/making-source-code-open/) **(DTA Blog (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [Open Source Code - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/4_Open_Source_Code.md)
@@ -282,3 +396,6 @@ Open source helps to:
 - [13. Default to open (Digital Services Playbook (US))](https://playbook.cio.gov/#play13)
 
 - [8. Make source code open (Digital Service Standard (AU))](https://www.dta.gov.au/standard/8-make-source-code-open/)
+
+</section>
+</section>

--- a/fr/6-utiliser-standards-solutions-ouverts.md
+++ b/fr/6-utiliser-standards-solutions-ouverts.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 6-use-open-standards-solutions
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -21,6 +27,10 @@ altLangPage: 6-use-open-standards-solutions
 
 [6.6 Nuage d'abord](#user-content-66-nuage-dabord)
 
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
+
 **Lignes directrices connexes:**
 
 [1.5 Fournir des services qui peuvent être convertis n'importe où, n'importe où et n'importe quel appareil (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-15-fournir-des-services-qui-peuvent-être-tout-quand-et-nimporte-quel-appareil)
@@ -33,7 +43,13 @@ altLangPage: 6-use-open-standards-solutions
 
 [10.3 Assurez-vous que les données sont collectées de manière standard afin qu'elles puissent être facilement intégrées et réutilisées par d'autres (Norme&#160;10&#160;: Soyez de bons gestionnaires de données)](10-soyez-bons-gestionnaires-donnees.md#user-content-103-assurez-vous-que-les-données-sont-collectées-de-manière-standard-afin-quelles-puissent-être-facilement-intégrées-et-réutilisées-par-dautres)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 6.1 Tirer parti des normes ouvertes et adopter des pratiques exemplaires
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -69,6 +85,10 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 **(Digital Service Standard (AU))**
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
@@ -80,6 +100,8 @@ move between different technologies when you need to, avoiding vendor lock-in.
 - Use emerging technologies **(Build It Right - OneGC Architectural Checklist (draft))**
   - Leverage new technologies (e.g., AI and blockchain) to shift investments to more modern tec
 
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+
 #### Stage alpha
 
 - build using the open standards of HTML, CSS and JavaScript to develop prototypes **(Digital Service Standard (AU))**
@@ -90,6 +112,10 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 - search for similar solutions in other jurisdictions. **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+
 #### Stages bêta et en direct
 
 - building using the Open Web Platform standards **(Digital Service Standard (AU))**
@@ -97,6 +123,11 @@ move between different technologies when you need to, avoiding vendor lock-in.
 - avoiding lock-in to any proprietary solutions where an open standard is available **(Digital Service Standard (AU))**
 
 - addressing any common user needs in a way that is consistent with the rest of government. **(Digital Service Standard (AU))**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -114,6 +145,10 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 - [OASIS Standards](https://www.oasis-open.org/standards)
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [Open Standards - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/2_Open_Standards.md)
@@ -124,13 +159,24 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 - [7. Use open standards and common platforms (Digital Service Standard (AU))](https://www.dta.gov.au/standard/7-open-standards-and-common-platforms/)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 6.2 Utiliser et réutiliser des solutions, des approches et des plates-formes gouvernementales courantes et éprouvées
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 The technology decisions we make need to enable development teams to work efficiently and enable services to scale easily and cost-effectively. Our choices for hosting infrastructure, databases, software frameworks, programming languages and the rest of the technology stack should seek to avoid vendor lock-in and match what successful modern consumer and enterprise software companies would choose today. In particular, digital services teams should consider using open source, cloud-based, and commodity solutions across the technology stack, because of their widespread adoption and support by successful consumer and enterprise technology companies in the private sector. **Digital Services Playbook (US))**
 
 In order to limit costs, avoid duplication of effort and provide a consistent client experience when using various services, the reuse and adaptation of existing technological solutions is encouraged, where appropriate. If the development of new solutions is required, consider the ability of others to reuse and adapt your work as this will provide additional value on an organizational level. **(2. Reuse, improve and share technological solutions where appropriate (Do - Digital Design Playbook (ISED)))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -183,9 +229,17 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
   - Open data leverages public sector information to develop consumer and commercial products.
   - Utilize the Government of Canada’s and ISED’s Application Programming Interface (API) Store.
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -197,11 +251,22 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 
 - [2. Reuse, improve and share technological solutions where appropriate (Do - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#2._Reuse.2C_improve_and_share_technological_solutions_where_appropriate)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 6.3 Conception pour l'interopérabilité, permettant aux services d'être découverts et exploités par la communauté
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 Les interfaces de programme d'application (API) sont un moyen par lequel les fonctionnalités métier sont exposées numériquement. Ce sont des éléments essentiels à la prestation réussie des services numériques en direct du gouvernement et à l'expansion de la prestation de services à des fournisseurs tiers. Ils peuvent également permettre une plus grande interopérabilité entre les services, optimiser les expériences entre les appareils et même mener à de nouveaux services novateurs en permettant à des produits tiers de fonctionner de façon transparente avec les systèmes du gouvernement du Canada.
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -223,6 +288,10 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
   - APIs created for every service, exposing data and functionality, to foster data sharing within GC and externally
   - Build microservices that work together within an ecosystem allowing for rapid deployment and built-in redundancy
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -233,13 +302,28 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 
 - [Application Programming Interfaces (APIs)](https://www.dta.gov.au/standard/design-guides/api/) **Digital Service Standard (AU)**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 6.4 Ouvrez les données, les transactions et les règles métier qui sous-tendent un service
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -253,11 +337,22 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 
 - [Application Programming Interfaces (APIs)](https://www.dta.gov.au/standard/design-guides/api/) **Digital Service Standard (AU)**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 6.5 Concevoir, créer et tester des services numériques de bout en bout
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 There are many potential benefits from the greater use of digital services, including greater convenience for users, quicker and more responsive service delivery, increased security and reliability and reduced costs. To maximize these potential benefits and avoid user reliance on less convenient ways of interacting with government, services should be designed to be digital from end-to-end.
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -293,9 +388,15 @@ There are many potential benefits from the greater use of digital services, incl
 
 - Conduct load and performance tests at regular intervals, including before public launch **(Digital Services Playbook (US))**
 
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+
 #### Stage alpha
 
 - test your prototypes with users. **(Digital Service Standard (AU))**
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Stage bêta et en direct
 
@@ -316,6 +417,11 @@ There are many potential benefits from the greater use of digital services, incl
 - show how you explored integrating automated testing into the deployment process **(Digital Service Standard (AU))**
 
 -show you have a business continuity plan and a roll-back option. **(Digital Service Standard (AU))**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -339,6 +445,10 @@ There are many potential benefits from the greater use of digital services, incl
 
 - [Testing Cookbook](https://testing-cookbook.18f.gov/) **(18F (US))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [10. Test the end-to-end service (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/test-the-end-to-end-service)
@@ -350,6 +460,11 @@ There are many potential benefits from the greater use of digital services, incl
 - [10. Automate testing and deployments (Digital Services Playbook (US))](https://playbook.cio.gov/#play10)
 
 - [10. Test the service (Digital Service Standard (AU))](https://www.dta.gov.au/standard/10-test-the-service/)
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
 
 ## 6.6 Nuage d'abord
 
@@ -372,6 +487,10 @@ Public cloud services offer benefits that enable significant advances in the fol
 - Cloud first **(Build It Right - OneGC Architectural Checklist (draft))**
   - SaaS considered first, PaaS, IaaS second to grow more modern infrastructure which includes public, private and hybrid cloud solutions
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
@@ -390,10 +509,21 @@ Public cloud services offer benefits that enable significant advances in the fol
 
 - Application is hosted on commodity hardware **(Digital Services Playbook (US))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [9. Deploy in a flexible hosting environment (Digital Services Playbook (US))](https://playbook.cio.gov/#play9)
+
+</section>
+</section>

--- a/fr/7-iterer-ameliorer-frequemment.md
+++ b/fr/7-iterer-ameliorer-frequemment.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 7-iterate-improve-frequently
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -17,6 +23,10 @@ altLangPage: 7-iterate-improve-frequently
 
 [7.4 Commencer petit et tester continuellement les conceptions et les hypothèses, en utilisant les preuves comme base de l'itération](#user-content-74-commencer-petit-et-tester-continuellement-les-conceptions-et-les-hypothèses-en-utilisant-les-preuves-comme-base-de-litération)
 
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
+
 **Lignes directrices connexesv:**
 
 [1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-12-simpliquer-aupr%C3%A8s-des-personnes-qui-ont-le-service-et-le-faire-participer-%C3%A0-toutes-les-%C3%A9tapes-de-la-planification-%C3%A0-lam%C3%A9lioration-continuer)
@@ -25,7 +35,13 @@ altLangPage: 7-iterate-improve-frequently
 
 [9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-92-innover-et-sam%C3%A9liorer-tout-en-r%C3%A9pondant-aux-attentes-du-public-quant-%C3%A0-la-protection-de-la-confidentialit%C3%A9-des-donn%C3%A9es)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 7.1 Construire de manière agile et améliorer continuellement en réponse aux besoins des utilisateurs
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -81,6 +97,10 @@ Use quantitative and qualitative data to help with regular reviews of your servi
 
 Start with a representation or prototype of the solution that will be tested and revised based on feedback and insights. Each iteration improves on the previous version. Your understanding of a problem and how to address it evolves each time you refine an idea and re-craft potential solutions. Taking an iterative approach also helps you reduce risks. It makes big failures less likely and turns mistakes into learning opportunities.
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
@@ -88,6 +108,8 @@ Start with a representation or prototype of the solution that will be tested and
 - Use agile **(Build It Right - OneGC Architectural Checklist (draft))**
   - Be an agile Developer: Develop in an iterative manner, with key stakeholders participation from the beginning, releasing minimum viable product as soon as possible and iteratively building out functionality
   - Be an agile administrator: Promote DEVOPS and automate, monitor and unify all platform and software construction from testing to release and infrastructure management
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -99,6 +121,10 @@ Start with a representation or prototype of the solution that will be tested and
 
 - determine the minimum viable product (MVP). **(Digital Service Standard (AU))
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+
 #### Stages bêta et en direct
 
 - show how the service has responded to user research and usability testing **(Digital Service Standard (AU))
@@ -106,6 +132,10 @@ Start with a representation or prototype of the solution that will be tested and
 - clearly describe the lifecycle of a user story, from user research to production **(Digital Service Standard (AU))
 
 - explain the deployment process and how you are able to support frequent deployments with minimal impact to users. **(Digital Service Standard (AU))
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Stages alpha, bêta et en direct
 
@@ -189,6 +219,11 @@ Start with a representation or prototype of the solution that will be tested and
 
 - be able to show that your governance is appropriate to the size and scale of your service, and that it is human-centred, based on clear and measurable goals, with a clear focus on managing change and risk in real time. **(Digital Service Standard (AU))**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -235,25 +270,65 @@ Start with a representation or prototype of the solution that will be tested and
 
 - [You can’t be half agile](https://gds.blog.gov.uk/2015/07/10/you-cant-be-half-agile/) **(Government Digital Service Blog (UK))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources connexes
+
+- [4. Use agile methods (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/use-agile-methods)
+
+- [8. Be agile and user-centred (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-9)
+
+- [4. Build the service using agile and iterative practices (Digital Services Playbook (US))](https://playbook.cio.gov/#play4)
+
+- [3. Review and improve services continually (Think - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Think#3._Review_and_improve_services_continually)
+
+- [3. Apply agile principles and be iterative. (Do - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#3._Apply_agile_principles_and_be_iterative.)
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
 
 ## 7.2 Accepter que le changement est inévitable et utiliser des stratégies et des outils adaptatifs pour de nouveaux développements
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 7.3 Embrasser et réagir aux changements dans l'environnement et concevoir pour la durabilité
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 Once you have designed and launched a service, there is still work to do. Treat the service as a product; it requires regular reviews, usability tests and improvements. Unlike a project that has pre-determined start and end date, a product has a life cycle that goes far beyond the launching of the service. Regularly assessing the service and welcoming opportunities for improvement will help to ensure that the service keeps pace with evolving client needs and benefits from new or improved technology. **(2. Product management, not just project management. (Assess - Digital Design Playbook (ISED)))**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -265,15 +340,30 @@ Once you have designed and launched a service, there is still work to do. Treat 
 
 - Identify opportunities to improve the service based on the results of regular test **(2. Product management, not just project management. (Assess - Digital Design Playbook (ISED)))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
 
 ### Ressources similaires
 
 - [2. Product management, not just project management. (Assess - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Assess#2._Product_management.2C_not_just_project_management.)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 7.4 Commencer petit et tester continuellement les conceptions et les hypothèses, en utilisant les preuves comme base de l'itération
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -288,6 +378,10 @@ You need to build a service which you can iterate and keep improving so that you
 - make sure your service keeps meeting user needs
 
 **1. Test the service before launching the service. (Assess - Digital Design Playbook (ISED))**: Services should be simple, inclusive and easy to use. Services should help clients achieve the outcomes that matter most. Assessing prototypes while the service is being designed will help you discover shortcomings that may deter clients from using the service or glitches that may affect the user experience. Assessing the service before it is officially launched will also help you make improvements that can go a long way in ensuring clients are satisfied when using the service. Rigorously and comprehensively testing the service from end-to-end is part of good service design.
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -321,6 +415,8 @@ You need to build a service which you can iterate and keep improving so that you
     - Card Sorting Testing - A reverse tree test where participants sort through items and group them together in a hierarchal manner.
     - First Click Testing - A test that observes the first item that a participant clicks on and uses the selection as an indication as to whether users are directed as intended.
 
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
+
 #### Stages alpha, bêta et en direct
 
 - document what you've built in each phase and why you built it **(Digital Service Standard (UK))**
@@ -341,17 +437,30 @@ You need to build a service which you can iterate and keep improving so that you
 
 - solve any technical problems you've found **(Digital Service Standard (UK))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+
 #### Stage bêta
 
 - determine how long you expect your service to be in beta and why **(Digital Service Standard (UK))**
 
 - document your way of [deploying software](https://www.gov.uk/service-manual/making-software/deployment.html), ie how you can deploy frequently with minimum impact on users **(Digital Service Standard (UK))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+
 #### Stage en direct
 
 - make sure deployments have zero downtime in a way that doesn't stop users using the service **(Digital Service Standard (UK))**
 
 - make sure you have enough staff to keep improving the service **(Digital Service Standard (UK))**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -379,8 +488,15 @@ Find out more about:
 
 - [Agile delivery](https://www.gov.uk/service-manual/agile-delivery) **(Digital Service Standard (UK))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [5. Iterate and improve frequently (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/iterate-and-improve-frequently)
 
 - [1. Test the service before launching the service. (Assess - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Assess#1._Test_the_service_before_launching_the_service.)
+
+</section>
+</section>

--- a/fr/8-concevoir-services-ethiques.md
+++ b/fr/8-concevoir-services-ethiques.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 8-design-ethical-services
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -16,6 +22,10 @@ altLangPage: 8-design-ethical-services
 [8.3 Se conformer aux directives éthiques dans la conception de systèmes automatisés](#user-content-83-se-conformer-aux-directives-éthiques-dans-la-conception-de-systèmes-automatisés)
 
 [8.4 Équilibrer les compromis entre innovation et inclusivité](#user-content-84-Équilibrer-les-compromis-entre-innovation-et-inclusivité)
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
@@ -47,52 +57,112 @@ altLangPage: 8-design-ethical-services
 
 [9.4 S'assurer que les services sont conformes à toutes les exigences législatives et réglementaires (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-94-sassurer-que-les-services-sont-conformes-%C3%A0-toutes-les-exigences-l%C3%A9gislatives-et-r%C3%A9glementaires)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 8.1 Soyez transparent au sujet des préjugés personnels et organisationnels et indiquez comment ils sont traités
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
 
 ## 8.2 Évaluer l'impact total sur les utilisateurs et les communautés
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
 
 ## 8.3 Se conformer aux directives éthiques dans la conception de systèmes automatisés
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-- Concevoir et fournir des services transparents et éthiques - Soyez ouvert et transparent dans l'utilisation des systèmes automatisés et conformez-vous aux directives éthiques.
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
 
 ## 8.4 Équilibrer les compromis entre innovation et inclusivité
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+</section>

--- a/fr/9-aborder-risques-securite-confidentialite.md
+++ b/fr/9-aborder-risques-securite-confidentialite.md
@@ -5,7 +5,13 @@ lang: fr
 altLang: en
 altLangPage: 9-address-security-privacy-risks
 ---
+<div markdown="1" class="dpgn-section-intro-standard">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
@@ -16,6 +22,10 @@ altLangPage: 9-address-security-privacy-risks
 [9.3 Faites en sorte que la sécurité soit fluide et sans friction, en équilibrant sécurité et commodité](#user-content-93-faites-en-sorte-que-la-sécurité-soit-fluide-et-sans-friction-en-équilibrant-sécurité-et-commodité)
 
 [9.4 S'assurer que les services sont conformes à toutes les exigences législatives et réglementaires](#user-content-94-sassurer-que-les-services-sont-conformes-à-toutes-les-exigences-législatives-et-réglementaires)
+
+</div>
+
+<div markdown="1" class="dpgn-section-guidelines-related">
 
 **Lignes directrives connexes :**
 
@@ -33,15 +43,29 @@ altLangPage: 9-address-security-privacy-risks
 
 [8.4 Équilibrer les compromis entre innovation et inclusivité (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-84-%C3%89quilibrer-les-compromis-entre-innovation-et-inclusivit%C3%A9)
 
+</div>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 9.1 Adopter une approche équilibrée de gestion des risques en mettant en œuvre des mesures de sécurité et de confidentialité appropriées
 
+<div markdown="1" class="dpgn-section-intro-guideline">
+
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
+
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
 - Permettre un partage sécurisé des informations et des données
+
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -51,7 +75,14 @@ altLangPage: 9-address-security-privacy-risks
 
 - [Secure services](https://www.dta.gov.au/standard/design-guides/secure-services/) **(Digital Service Standards (AU))**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -69,9 +100,15 @@ Users won't use a service unless they have a guarantee:
 
  **(Digital Service Standard (Ontario))**
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -93,6 +130,10 @@ Users won't use a service unless they have a guarantee:
 
 - document the privacy policy and rationale **(Digital Service Standard (Ontario))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+
 #### Stage en direct
 
 - make sure there are ongoing interactions with the business and information risk teams (for example, Corporate Security and Information, Privacy and Archives) **(Digital Service Standard (Ontario))**
@@ -101,27 +142,50 @@ Users won't use a service unless they have a guarantee:
 
 - make sure the privacy policy stays up-to-date **(Digital Service Standard (Ontario))**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
+### Ressources similaires
+
+- [10. Intégrer la sécurité et la protection de la vie privée au niveau de la conception (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-11)
+
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 9.3 Faites en sorte que la sécurité soit fluide et sans friction, en équilibrant sécurité et commodité
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
-Identify the data the service will use, store or create. Put appropriate legal, privacy and security measures in place so that users feel confident that their personal information will be kept secure and their privacy will be respected.
+Identifiez les données que le service utilisera, stockera ou créera. Adoptez des mesures appropriées en matière juridique, de sécurité et de protection de la vie privée de façon à ce que les utilisateurs soient certains que leurs renseignements personnels seront conservés en toute sécurité et que la protection de leur vie privée sera assurée.
 
-Users won't use a service unless they have a guarantee:
+Pour que les utilisateurs utilisent un service, il est nécessaire de garantir les points suivants :
 
-- it's secure
+- sécurité du service
 
-- it's confidential
+- confidentialité du service
 
-- they can access their information in the service when they need to
+- possibilité d’accéder à ses renseignements au sein du service lorsqu'on en a besoin
+- que leur vie privée sera respectée pendant et après l’usage de ce service
 
-- that their privacy is protected while they use the service, and afterwards
+ **(Normes des services numériques (Ontario))**
 
- **(Digital Service Standard (Ontario))**
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -129,6 +193,8 @@ Users won't use a service unless they have a guarantee:
 
 - Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
   - Embed all services in Pan-Canadian Trust Framework to foster multi-jurisdictional service delivery
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -156,6 +222,10 @@ Users won't use a service unless they have a guarantee:
 
 - plan for checking suspicious activity **(Digital Service Standard (Ontario))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+
 #### Stage en direct
 
 - document the approach to security and risk management **(Digital Service Standard (Ontario))**
@@ -164,15 +234,31 @@ Users won't use a service unless they have a guarantee:
 
 - document the process for understanding new or ongoing threats and how those changed during beta **(Digital Service Standard (Ontario))**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
+
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
 
 ### Ressources similaires
 
 - [10. Intégrer la sécurité et la protection de la vie privée au niveau de la conception (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-11)
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guideline">
+
 ## 9.4 S'assurer que les services sont conformes à toutes les exigences législatives et réglementaires
+
+<div markdown="1" class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -203,6 +289,10 @@ People who use government services must have confidence that:
 
 If a service cannot guarantee confidentiality, integrity and availability of the system, people will not use it.
 
+</div>
+
+<section markdown="1" class="dpgn-section-checklist">
+
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
@@ -225,6 +315,8 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 - HTTPS only **(Build It Right - OneGC Architectural Checklist (draft))**
   - Holistic approach to securing GC services for publicly accessible sites
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -264,6 +356,10 @@ If a service cannot guarantee confidentiality, integrity and availability of the
   - the Freedom of Information Act
   - the Spam Act
   - state and territory government policies, if relevant.
+
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -306,6 +402,10 @@ If a service cannot guarantee confidentiality, integrity and availability of the
   - logging solution that can fully trace a user as they traverse each part of the system
   - appropriate business rules that check the validity of interactions with the solution.
 
+</section>
+
+<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+
 #### Stage en direct
 
 - determine your team's approach to security and risk management **(Digital Service Standard (UK))**
@@ -330,6 +430,11 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 - have mitigated all known vulnerabilities in the solution. **(Digital Service Standard (AU))**
 
+</section>
+</section>
+
+<section markdown="1" class="dpgn-section-guides">
+
 ### Guides d'implémentation
 
 **\[TODO: Ajouter / réviser les éléments du guide de mise en œuvre\]**
@@ -344,6 +449,10 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 - [Secure services](https://www.dta.gov.au/standard/design-guides/secure-services/) **(Digital Service Standard (AU))**
 
+</section>
+
+<section markdown="1" class="dpgn-section-similar">
+
 ### Ressources similaires
 
 - [7. Understand security and privacy issues (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/understand-security-and-privacy-issues)
@@ -351,3 +460,6 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 - [11. Manage security and privacy through reusable processes (Digital Services Playbook (US))](https://playbook.cio.gov/#play11)
 
 - [5. Make it secure (Digital Service Standard (AU))](https://www.dta.gov.au/standard/5-make-it-secure/)
+
+</section>
+</section>

--- a/fr/apercu.md
+++ b/fr/apercu.md
@@ -37,7 +37,7 @@ ses citoyens.   Il a fallu une communauté de personnes, avec des antécédents 
 
 1. [Concevoir avec les utilisateurs](1-concevoir-avec-utilisateurs.md)
 1. [Construire dans l'accessibilité dès le début](2-construire-dans-accessibilite-des-debut.md)
-1. [Collaborez](3-collaborez-largement.md)
+1. [Collaborez largement](3-collaborez-largement.md)
 1. [Habiliter le personnel à fournir des meilleurs services](4-habiliter-personnel-fournir-meilleurs-services.md)
 1. [Travailler à l'air libre par défaut](5-travailler-air-libre-par-defaut.md)
 1. [Utiliser des standards et solutions ouverts](6-utiliser-standards-solutions-ouverts.md)


### PR DESCRIPTION
- Added French section and div elements to each standard for use with the filtering interface
- Fixed display of the French header and footer (incorrectly displayed in English)
- Added/removed content that was in the English version but not the French version (and vice-versa)
- Fixes #60 (last part of the multi-part fix)