### PR TITLE
 Auto-generate guidelines links and compress related guidelines

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,9 @@ wet_cdts_hosturl: "https://www.canada.ca/etc/designs/canada/cdts/gcweb"
 wet_cdts_version: "v4_0_27"
 exclude: ['CONTRIBUTING.md', 'LICENSE.md', 'README.md', 'node_modules/**/*.md' ]
 markdown: kramdown
+kramdown:
+  parse_block_html: true
+  toc_levels: "2..2"
 
 # Translations
 title:

--- a/en/1-design-with-users.md
+++ b/en/1-design-with-users.md
@@ -15,8 +15,10 @@ altLangPage: 1-concevoir-avec-utilisateurs
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 
@@ -55,23 +57,14 @@ Users should be involved throughout the lifecycle of the service, with user rese
 ### Checklist
 
 - Interview potential users to help develop the following for the service:
-
     a.  User goals (e.g., As a \[user type\], I want \[some goal\] so that \[some reason\])
-
     b.  User personas (e.g., based on habits, personality, attitudes and motives)
-
     c.  User profiles (e.g., based on demographics such as gender, age, location, income and family size)
-
 - Use a range of qualitative and quantitative research methods to determine people's goals, needs, and behaviors
-
 - Create and maintain a list of priority tasks that users are trying to accomplish (i.e., "user stories")
-
 - Regularly test with users when building the service and after the service has been launched to ensure it meets the needs of user and to identify any parts of the service that users may find difficult
-
 - Put in place a plan to pay for user research and usability tests throughout the design of the service and after it's built
-
 - Use qualitative and quantitative data to help improve your understanding of user needs and identify areas for improvement
-
 - Provide a mechanism for users to provide feedback and to address service issues in a timely manner (as required by the [Policy on Service](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=27916#cha7).
 
 </section>
@@ -114,11 +107,8 @@ User needs are constantly evolving which it is why it is important to plan for o
 #### Alpha stage
 
 - determine what your private beta will look like and how you'll use what you find to improve the service **(Digital Service Standard (UK))**
-
 - pay for user research and usability tests throughout the design of the service and after it's built **(Digital Service Standard (UK))**
-
 - carry out research and usability tests regularly and use the results to improve the design of your service **(Digital Service Standard (UK))**
-
 - develop a user research plan for private beta and a plan for carrying out user research on the live service **(Digital Service Standard (UK))**
 
 </section>
@@ -128,19 +118,12 @@ User needs are constantly evolving which it is why it is important to plan for o
 #### Beta and live stages
 
 - pay for user research and usability tests throughout the design of the service and after the service is built **(Digital Service Standard (UK))**
-
 - carry out research and usability tests regularly and use the results to improve the design of your service **(Digital Service Standard (UK))**
-
 - develop a user research plan for the service at the next phase and a plan for carrying out user research on the live service **(Digital Service Standard (UK))**
-
 - do user research with people who have accessibility needs from the time you started designing the service **(Digital Service Standard (UK))**
-
 - test with users who need assisted digital support **(Digital Service Standard (UK))**
-
 - use analytics data in your user research plan for the service **(Digital Service Standard (UK))**
-
 - document any problems you've found through testing and how you solved them **(Digital Service Standard (UK))**
-
 - document any problems you haven't been able to solve in beta and how you'll handle them in public beta **(Digital Service Standard (UK))**
 
 </section>
@@ -187,25 +170,15 @@ A key part of building digital services that work for users is developing a good
 #### Alpha stage
 
 - Spend time with current and prospective users of the service **(Digital Services Playbook (US))**
-
 - Test prototypes of solutions with real people, in the field if possible **(Digital Services Playbook (US))**
-
 - As the digital service is being built, regularly test it with potential users to ensure it meets people's needs **(Digital Services Playbook (US))**
-
 - Use a range of qualitative and quantitative research methods to determine people's goals, needs, and behaviors; be thoughtful about the time spent **(Digital Services Playbook (US))**
-
 - Create a prioritized list of tasks the user is trying to accomplish, also known as "user stories" **(Digital Services Playbook (US))**
-
 - Identify parts of the service that users find difficult and any problems that need to be overcome to design the service **(Digital Service Standard (Ontario))**
-
 - **Who are the users?** What about their motivations, triggers, contexts are significant for your service? How can you find them to invite them to participate in user research? You must include users with varying needs (such as needs arising from disability, cultural diversity, literacy and remoteness). Consider all the users in the service including end users, users in government who are delivering the service, and key intermediaries (professional and personal network) **(Digital Service Standard (AU))**
-
 - **What is the real task(s) that people are trying to achieve** when they encounter your service. What is the ‘job’ people are trying to get done that your service is a part of? (You need to describe this in words that real end users would use, not using government terminology) **(Digital Service Standard (AU))**
-
 - **How are users currently doing the task** your service aims to help them do and key touch points, for example through journey maps. What other relevant government and non-government services are also in use at this time? Where are the pain points in the current experience? **(Digital Service Standard (AU))**
-
 - **What are the user needs?** What are the opportunities to remove or reduce the pain points? How might we better meet the user needs? (Demonstrate this through research, testing and validating possible solutions with prototypes) **(Digital Service Standard (AU))**
-
 - **Are you designing the right thing?** How have your insights from user research helped you to define your minimum viable product (MVP)? How does the MVP create value for users and government by better meeting user needs? **(Digital Service Standard (AU))**
 
 </section>
@@ -215,31 +188,18 @@ A key part of building digital services that work for users is developing a good
 #### Beta stage
 
 - Research with users during the private beta, including users who need assisted digital support **(Digital Service Standard (UK))**
-
 - Document the process used for the private beta, including how many users you tested with, how you recruited them, how you used analytics in your research, and what you learned that you didn't find in alpha **(Digital Service Standard (UK))**
-
 - Document who your users are and what you've done to understand their needs, including users who need assisted digital support **(Digital Service Standard (UK))**
-
 - Document the design challenges your users' needs pose for your service **(Digital Service Standard (UK))**
-
 - Identify parts of the task which users find difficult and change the service to make these parts of the task easier for users, testing and researching to confirm this **(Digital Service Standard (UK))**
-
 - Document user stories, personas or profiles for your service - ie identify people who need to use the service and what they use it for, including users who need assisted digital support **(Digital Service Standard (UK))**
-
 - Document any problems that you found in research which you'll have to overcome to design the service **(Digital Service Standard (UK))**
-
 - Document how the design of the service has changed over time because of what you found in user research **(Digital Service Standard (UK))**
-
 - Greater depth and diversity of knowledge on all of the points above from Alpha **(Digital Service Standard (AU))**
-
 - **How has your service been shaped by user needs?** Show how you have made changes in the service and interaction design in response to user research and usability testing. You can evidence this by showing how the design has changed over time and the appropriate research findings that have driven this change **(Digital Service Standard (AU))**
-
 - **How you tested the system in the users’ context with a full range of users** (including users with varying needs). You can evidence this with artefacts of research, for example, video clips and outcomes from research analysis **(Digital Service Standard (AU))**
-
 - **Are you prepared for ongoing user research?** Show how you plan to continue to test the system with users and the resources for this, for example through an ongoing research plan and budget **(Digital Service Standard (AU))**
-
 - **What have you not solved yet?** What the significant design challenges are, for example through key insights, how have you approached them? How do you plan to continue to tackle them? **(Digital Service Standard (AU))**
-
 - **How will you know if your design is working?** Make sure that research has fed into the metrics you have developed to know that you continue to meet your user needs **(Digital Service Standard (AU))**
 
 </section>
@@ -249,13 +209,9 @@ A key part of building digital services that work for users is developing a good
 #### Live stage
 
 - Use research and testing results to continuously improve the service **(Digital Service Standard (Ontario))**
-
 - Identify parts of the task which users find difficult and change the service to make these parts of the task easier for users, testing and researching to confirm this **(Digital Service Standard (UK))**
-
 - Be able to show greater depth of knowledge for all the points above (from Alpha/Beta) **(Digital Service Standard (AU))**
-
 - **Show how you are using data from real use** to understand which parts of the task users are finding difficult and how you are designing experiments to reduce friction and increase success for users **(Digital Service Standard (AU))**
-
 - Know how you will measure and monitor your service to ensure it is serving its users well **(Digital Service Standard (AU))**
 
 </section>
@@ -268,39 +224,22 @@ A key part of building digital services that work for users is developing a good
 **[TODO: Add/revise implementation guide items]**
 
 - [Start by learning user needs](https://www.gov.uk/service-manual/user-research/start-by-learning-user-needs) **(Digital Service Standard (UK))**
-
 - [Improve service design with user research](https://www.gov.uk/service-manual/user-research/how-user-research-improves-service-design) **(Digital Service Standard (UK))**
-
 - [Introduction to User-centred Design](http://www.usabilityfirst.com/about-usability/introduction-to-user-centered-design/)
-
 - [User Research Skills](https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team) **(Digital Service Standard (UK))**
-
 - [How Users Read](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#how-people-read) **(Writing for GOV.UK)**
-
 - [Designing government services](https://www.gov.uk/service-manual/design/introduction-designing-government-services) **(Digital Service Standard (UK))**
-
 - [DTA Guide to Discovery](https://ausdto.github.io/service-handbook/discovery/) **(Service Handbook (AU))**
-
 - [DTA Guide to Alpha](http://ausdto.github.io/service-handbook/alpha/) **(Service Handbook (AU))**
-
 - [Doing user research in the discovery phase](https://userresearch.blog.gov.uk/2015/05/27/doing-user-research-in-the-discovery-phase/) **(Government Digital Service Blog (UK))**
-
 - [Understanding the problem is key to fixing it](https://userresearch.blog.gov.uk/2016/01/12/understanding-the-problem-is-key-to-fixing-it/) **(Government Digital Service Blog (UK))**
-
 - [Users research not just usability](https://userresearch.blog.gov.uk/2014/06/25/user-research-not-just-usability/) **(Government Digital Service Blog (UK))**
-
 - [User research for government services 8 strategies that worked for us](https://userresearch.blog.gov.uk/2015/01/21/user-research-for-government-services-8-strategies-that-worked-for-us/) **(Government Digital Service Blog (UK))**
-
 - [How we do user research in agile teams](https://gds.blog.gov.uk/2013/08/30/how-we-do-user-research-in-agile-teams/) **(Government Digital Service Blog (UK))**
-
 - [Including users with low digital skills in user research](https://userresearch.blog.gov.uk/2014/08/20/including-users-with-low-digital-skills-in-user-research/) **(Government Digital Service Blog (UK))**
-
 - [Using prototypes in user research](https://userresearch.blog.gov.uk/2014/08/27/using-prototypes-in-user-research/) **(Government Digital Service Blog (UK))**
-
 - [How designers prototype at GDS](https://designnotes.blog.gov.uk/2014/10/13/how-designers-prototype-at-gds/) **(Government Digital Service Blog (UK))**
-
 - [Method Cards](https://methods.18f.gov/index.html) **(18F (US))**
-
 - [Evangelising user research](https://medium.com/@userfocus/evangelising-user-research-849430701b6e) **(David Travis (Medium.com))**
 
 </section>
@@ -310,13 +249,9 @@ A key part of building digital services that work for users is developing a good
 ### Similar resources
 
 - [1. Understand user needs (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/understand-user-needs)
-
 - [1. Understand users and their needs (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-2)
-
 - [1. Understand what people need (Digital Services Playbook (US))](https://playbook.cio.gov/#play1)
-
 - [1. Understand user needs (Digital Service Standard (AU))](https://www.dta.gov.au/standard/1-user-needs/)
-
 - [1. Understand client needs (Think - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Think#1._Understand_client_needs)
 
 </section>
@@ -340,11 +275,8 @@ We need to understand the different ways people will interact with our services,
 **[TODO: Add/revise checklist items]**
 
 - Understand the different points at which people will interact with the service -- both online and in person **(Digital Services Playbook (US))**
-
 - Identify pain points in the current way users interact with the service, and prioritize these according to user needs **(Digital Services Playbook (US))**
-
 - Design the digital parts of the service so that they are integrated with the offline touch points people use to interact with the service **(Digital Services Playbook (US))**
-
 - Develop metrics that will measure how well the service is meeting user needs at each step of the service **(Digital Services Playbook (US))**
 
 </section>
@@ -383,7 +315,6 @@ We need to understand the different ways people will interact with our services,
 **[TODO: Add/revise checklist items]**
 
 - Ensure that services are designed for the mobile digital channel first, and then adapted to other service channels. Refer to the related technical standard. **(General design principles - Digital Design Playbook (ISED))**
-
 - Platform agnostic **(Build It Right - OneGC Architectural Checklist (draft))**
   - Build applications for easy deployment and portability regardless of platform/operating system by default (e.g., open standard containers)
 
@@ -439,45 +370,26 @@ Writing and designing content so it is consistent, plain and in the language of 
 **[TODO: Add/revise checklist items]**
 
 - Test the name of the service and see if it makes sense to users **(Digital Service Standard (Ontario))**
-
 - Give users clear information about where they are in each step of the process **(Digital Services Playbook (US))**
-
 - Provide users with a way to exit and return later to complete the process **(Digital Services Playbook (US))**
-
 - Use language that is familiar to the user and easy to understand **(Digital Services Playbook (US))**
-
 - Use language and design consistently throughout the service, including online and offline touch points **(Digital Services Playbook (US))**
-
 - Make sure most people can get through the service end-to-end without assistance **(Digital Service Standard (UK))**
-
 - Use analytics and user research to reduce the number of people who didn't complete the task they set out to do online (e.g. renew a driver's licence) **(Digital Service Standard (Ontario))**
-
 - Use research, testing and analytics to make substantial iterations to your service, including the assisted digital support model **(Digital Service Standard (UK))**
-
 - Document all end-to-end user journeys, including assisted digital journeys, demonstrate that they work and how you tested them **(Digital Service Standard (UK))**
-
 - Make the service accessible, including for users with lower levels of digital skills **(Digital Service Standard (Ontario))**
-
 - Make sure the service is responsive, with the same content and functionality on all devices, and works on mobile devices **(Digital Service Standard (Ontario))**
-
 - Do usability testing:
   - including with users with the lowest level of digital skills **(Digital Service Standard (UK))**
   - at least once before and after the service goes live and make improvements accordingly **(Digital Service Standard (Ontario))**
-
 - Make design and content decisions based on research, testing and analytics **(Digital Service Standard (Ontario))**
-
 - change the interface design in response to usability testing, documenting the hypotheses you tested, what happened and how you reacted **(Digital Service Standard (UK))**
-
 - Make sure the service is responsive and works on mobile devices **(Digital Service Standard (UK))**
-
 - understand how you will use responsive design for platform independence **(Digital Service Standard (AU))**
-
 - understand how you will use existing design patterns and a front-end toolkit to make the service consistent **(Digital Service Standard (AU))**
-
 - create simpler and clearer information by understanding the language of your users, using plain language by default, and applying contemporary online writing methods **(Digital Service Standard (AU))**
-
 - follow accessibility better practice and are planning how your public prototype will meet WCAG 2.0 level AA **(Digital Service Standard (AU))**
-
 - ensure appropriate design, content design and front-end developer support is provided to the team. **(Digital Service Standard (AU))**
 
 </section>
@@ -489,19 +401,12 @@ Writing and designing content so it is consistent, plain and in the language of 
 **[TODO: Add/revise implementation guide items]**
 
 - [How user research improves service design](https://www.gov.uk/service-manual/user-research/how-user-research-improves-service-design) **(Digital Service Standard (UK))**
-
 - [Start by learning user needs](https://www.gov.uk/service-manual/user-research/start-by-learning-user-needs) **(Digital Service Standard (UK))**
-
 - [Understanding users who don't use digital services](https://www.gov.uk/service-manual/user-research/understanding-users-who-dont-use-digital-services) **(Digital Service Standard (UK))**
-
 - [Design patterns](https://www.gov.uk/service-manual/user-centred-design/resources/patterns/index.html) **(Digital Service Standard (UK))**
-
 - [Australian Government Style manual](http://www.australia.gov.au/about-government/publications/style-manual)
-
 - [18F Content Guide](https://content-guide.18f.gov/) **(18F (US))**
-
 - [Looking at the different ways to test content](https://18f.gsa.gov/2016/04/19/looking-at-the-different-ways-to-test-content/) **(18F (US))**
-
 - [Government Digital Service (GDS) style guide](https://www.gov.uk/guidance/style-guide)  **(Government Digital Service (UK))**
 
 </section>
@@ -511,15 +416,10 @@ Writing and designing content so it is consistent, plain and in the language of 
 ### Similar resources
 
 - [12. Make sure users succeed first time (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/create-a-service-thats-simple)
-
 - [13. Make the user experience consistent with GOV.UK (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/make-the-user-experience-consistent-with-govuk)
-
 - [3. Be consistent (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-4)
-
 - [5. Ensure users succeed the first time (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-6)
-
 - [3. Make it simple and intuitive (Digital Services Playbook (US))](https://playbook.cio.gov/#play3)
-
 - [6. Consistent and responsive design (Digital Service Standard (AU))](https://www.dta.gov.au/standard/6-consistent-and-responsive/)
 
 </section>
@@ -538,9 +438,7 @@ Encourage people to choose the digital service through every interaction they ha
 Encouraging people to use digital service will:
 
 - save money by reducing the number of people using non-digital channels, such as call centres
-
 - help users to develop their digital skills
-
 - give better support to those who can't use digital services on their own
 
 **(Digital Service Standard (Ontario))**
@@ -574,35 +472,20 @@ We still need to help users who are unable to use digital channels and provide s
 #### Alpha stage
 
 - Plan to increase how many people use the digital service **(Digital Service Standard (Ontario))**
-
 - Understand other channels that the service is delivered through **(Digital Service Standard (Ontario))**
-
 - Collect data on service usage for each channel **(Digital Service Standard (UK))**
-
 - Identify organizations and groups that help users with existing digital or non-digital services **(Digital Service Standard (Ontario))**
-
 - Gather insights from research with users, including demographics, attitudes, behaviours and channel preferences, and user journey maps **(Digital Service Standard (Ontario))**
-
 - Understand how each channel meets different users' needs **(Digital Service Standard (Ontario))**
-
 - Design the digital service in a way that gives it clear advantages over other channels **(Digital Service Standard (Ontario))**
-
 - show you understand all the touchpoints in users’ journeys, their contexts of use, and the digital limitations affecting different groups of users **(Digital Service Standard (Ontario))**
-
 - show you understand existing channels and how they interact with the service and with each other **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
-
 - show you understand the channels required to support all groups of users of the service, and where a user may need to change channels **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
-
 - show you understand if there are any repeat transactions by users over different channels **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
-
 - show you understand the interactions occurring between the channels that deliver and capture user transactions. **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
-
 - show you understand the users’ journeys and how they interact with your service, digitally or otherwise **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - show you understand existing alternative channels and how users currently interact with them **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - show you understand what percentage of users access digital and non-digital channels **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - show you understand how you will increase digital take-up and what targets you will set. **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
 
 </section>
@@ -612,19 +495,12 @@ We still need to help users who are unable to use digital channels and provide s
 #### Beta stage
 
 - Plan to increase how many people use the digital service and show the evidence **(Digital Service Standard (Ontario))**
-
 - Collect weekly analytics or metrics for usage volumes across channels **(Digital Service Standard (UK))**
-
 - Improve the way you communicate with users based on user insight **(Digital Service Standard (UK))**
-
 - Collect analytics data that shows how your new ways of communicating have performed **(Digital Service Standard (UK))**
-
 - be increasing digital take-up; revising your targets and considering relevant performance metrics **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - have a plan of how to move users to the digital channel where possible, including a communications plan to promote the service **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - have agreed analytics/metrics for the volume of usage across channels **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - understand the full impact of retiring any potentially redundant services and channels. **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
 
 </section>
@@ -634,19 +510,12 @@ We still need to help users who are unable to use digital channels and provide s
 #### Live stage
 
 - Plan for moving users to the digital service including yearly targets for increasing digital take-up for the next 5 years **(Digital Service Standard (UK))**
-
 - Measure usage volumes (and trends) per channel **(Digital Service Standard (UK))**
-
 - Measure the expected impact on other service points, such as phone and in person, and how that could impact funding and resource allocation **(Digital Service Standard (Ontario))**
-
 - show how you’ve revised the targets you made in the Beta stage to increase the number of users (including users we need to assist) of your digital service **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - show what you’ve learned from testing different approaches to encourage users (including users we need to assist) to choose the digital service over non-digital alternatives, and which ones you’ll use in the Live stage **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - show your retirement strategy for any redundant services and channels **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - show that your service load capacity is scalable to meet increased digital take-up **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
-
 - show how you will promote your service and encourage people to use it, including how your messaging will appear in places where the users will see it. **(13. Encourage everyone to use the digital service - Digital Service Standard (AU))**
 
 </section>
@@ -656,9 +525,7 @@ We still need to help users who are unable to use digital channels and provide s
 #### Beta and live stages
 
 - detail the channels required to support all groups of users of the service **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
-
 - understand the non-digital service channels and have a plan to move users to the digital channel where appropriate **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
-
 - have developed and tested the service so that a user can change channels without repeating themselves. **(12. Don’t forget the non-digital experience - Digital Service Standard (AU))**
 
 </section>
@@ -671,9 +538,7 @@ We still need to help users who are unable to use digital channels and provide s
 **[TODO: Add/revise implementation guide items]**
 
 - [How to measure digital take-up](https://www.gov.uk/service-manual/measuring-success/measuring-digital-take-up) **(Digital Service Standard (UK))**
-
 - [Encouraging people to use your digital service](https://www.gov.uk/service-manual/helping-people-to-use-your-service/encouraging-people-to-use-your-digital-service) **(Digital Service Standard (UK))**
-
 - [Assisted Digital](https://www.dta.gov.au/standard/design-guides/assisted-digital/) **(Digital Service Standard (AU))**
 
 </section>
@@ -683,11 +548,8 @@ We still need to help users who are unable to use digital channels and provide s
 ### Similar resources
 
 - [14. Encourage everyone to use the digital service (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/encourage-everyone-to-use-the-digital-service)
-
 - [11. Encourage people to use digital services (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-12)
-
 - [12. Don’t forget the non-digital experience (Digital Service Standard (AU))](https://www.dta.gov.au/standard/12-non-digital-experience/)
-
 - [13. Encourage everyone to use the digital service (Digital Service Standard (AU))](https://www.dta.gov.au/standard/13-encourage-use-of-the-digital-service/)
 
 </section>
@@ -717,21 +579,16 @@ You need to have a plan for what to do if your service goes offline so that you 
 **[TODO: Add/revise checklist items]**
 
 - Leverage opportunities across multiple channels, implementing the relevant GC Policy requirements for each channel
-
 - Do user research as early as possible to: **(Digital Service Standard (Ontario))**
   - understand users' digital skill, confidence and access
   - find out why some users can't use the digital service independently, for example language or internet barriers
   - find out user needs for support
-
 - Conduct research with users who: **(Digital Service Standard (Ontario))**
   - already use the service or would use it
   - have the lowest level of digital skills, confidence and access
   - currently seek assisted digital support from others (like friends and family, colleagues, companies or charities)
-
 - Determine how users would be affected if your service was unavailable for any length of time and how that's changed since beta **(Digital Service Standard (UK))**
-
 - Determine the most likely ways the service could go offline and how you plan to stop them **(Digital Service Standard (UK))**
-
 - Determine your strategy for dealing with outages, including who's responsible and the decisions they can make **(Digital Service Standard (UK))**
 
 </section>
@@ -743,7 +600,6 @@ You need to have a plan for what to do if your service goes offline so that you 
 **[TODO: Add/revise implementation guide items]**
 
 - [Keeping your service online](https://www.gov.uk/service-manual/technology/uptime-and-availability-keeping-your-service-online) **(Digital Service Standard (UK))**
-
 - [Assisted Digital](https://www.dta.gov.au/standard/design-guides/assisted-digital/) **(Digital Service Standard (AU))**
 
 </section>
@@ -753,7 +609,6 @@ You need to have a plan for what to do if your service goes offline so that you 
 ### Similar resources
 
 - [11. Make a plan for being offline (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/make-a-plan-for-being-offline)
-
 - [12. Support those who need it (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-13)
 
 </section>

--- a/en/1-design-with-users.md
+++ b/en/1-design-with-users.md
@@ -5,67 +5,44 @@ lang: en
 altLang: fr
 altLangPage: 1-concevoir-avec-utilisateurs
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[1.1 Build nothing for the user, without the user being involved](#user-content-11-build-nothing-for-the-user-without-the-user-being-involved)
-
-[1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements](#user-content-12-empathize-with-the-people-using-the-service-and-have-them-engaged-at-all-stages-from-planning-to-ongoing-improvements)
-
-[1.3 Understand the context in which people are interacting and design appropriate solutions that meet their needs](#user-content-13-understand-the-context-in-which-people-are-interacting-and-design-appropriate-solutions-that-meet-their-needs)
-
-[1.4 Clearly articulate and understand the end-to-end problem and use data to demonstrate that it is being solved](#user-content-14-clearly-articulate-and-understand-the-end-to-end-problem-and-use-data-to-demonstrate-that-it-is-being-solved)
-
-[1.5 Provide services that can be obtained anytime, anywhere and on any device](#user-content-15-provide-services-that-can-be-obtained-anytime-anywhere-and-on-any-device)
-
-[1.6 Make services simple, intuitive and consistent](#user-content-16-make-services-simple-intuitive-and-consistent)
-
-[1.7 Make it more convenient and practical to use digital services](#user-content-17-make-it-more-convenient-and-practical-to-use-digital-services)
-
-[1.8 Support people who cannot use digital services on their own](#user-content-18-support-people-who-cannot-use-digital-services-on-their-own)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[2.1 Build for those with the greatest needs and it will work for everyone else (Standard 2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-21-build-for-those-with-the-greatest-needs-and-it-will-work-for-everyone-else)
-
-[2.2 Services should meet or exceed accessibility standards, and should not feel burdensome to use (Standard 2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-22-services-should-meet-or-exceed-accessibility-standards-and-should-not-feel-burdensome-to-use)
-
-[2.3 Co-create with people who have distinct needs, being inclusive from the very beginning (Standard 2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-23-co-create-with-people-who-have-distinct-needs-being-inclusive-from-the-very-beginning)
-
-[2.4 Take into consideration a user's possible constraints when designing services (Standard 2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-24-take-into-consideration-a-users-possible-constraints-when-designing-services)
-
-[3.2 Recognize that an organization can't have all the best ideas, create partnerships and collaborate with a diverse range of partners (Standard 3: Collaborate widely)](3-collaborate-widely.md#user-content-32-recognize-that-an-organization-cant-have-all-the-best-ideas-create-partnerships-and-collaborate-with-a-diverse-range-of-partners)
-
-[6.5 Design, build and test end-to-end digital services (Standard 6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-65-design-build-and-test-end-to-end-digital-services)
-
-[7.1 Build in an agile manner and continuously improve in response to user needs (Standard 7: Iterate and improve frequently)](7-iterate-improve-frequently.md#user-content-71-build-in-an-agile-manner-and-continuously-improve-in-response-to-user-needs)
-
-[7.4 Start small and test designs and assumptions continually, using evidence as the basis for iteration (Standard 7: Iterate and improve frequently)](7-iterate-improve-frequently.md#user-content-74-start-small-and-test-designs-and-assumptions-continually-using-evidence-as-the-basis-for-iteration)
-
-[8.2 Assess the full impact on users and communities (Standard 8: Design ethical services)](8-design-ethical-services.md#user-content-82-assess-the-full-impact-on-users-and-communities)
-
-[8.4 Balance trade-offs between innovation and inclusiveness (Standard 8: Design ethical services)](8-design-ethical-services.md#user-content-84-balance-trade-offs-between-innovation-and-inclusiveness)
-
-[10.1 Collect data once to avoid duplication (Standard 10: Be good data stewards)](10-be-good-data-stewards.md#user-content-101-collect-data-once-to-avoid-duplication)
+- [2.1 Build for those with the greatest needs and it will work for everyone else (Standard 2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-21-build-for-those-with-the-greatest-needs-and-it-will-work-for-everyone-else)
+- [2.2 Services should meet or exceed accessibility standards, and should not feel burdensome to use (Standard 2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-22-services-should-meet-or-exceed-accessibility-standards-and-should-not-feel-burdensome-to-use)
+- [2.3 Co-create with people who have distinct needs, being inclusive from the very beginning (Standard 2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-23-co-create-with-people-who-have-distinct-needs-being-inclusive-from-the-very-beginning)
+- [2.4 Take into consideration a user's possible constraints when designing services (Standard 2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-24-take-into-consideration-a-users-possible-constraints-when-designing-services)
+- [3.2 Recognize that an organization can't have all the best ideas, create partnerships and collaborate with a diverse range of partners (Standard 3: Collaborate widely)](3-collaborate-widely.md#user-content-32-recognize-that-an-organization-cant-have-all-the-best-ideas-create-partnerships-and-collaborate-with-a-diverse-range-of-partners)
+- [6.5 Design, build and test end-to-end digital services (Standard 6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-65-design-build-and-test-end-to-end-digital-services)
+- [7.1 Build in an agile manner and continuously improve in response to user needs (Standard 7: Iterate and improve frequently)](7-iterate-improve-frequently.md#user-content-71-build-in-an-agile-manner-and-continuously-improve-in-response-to-user-needs)
+- [7.4 Start small and test designs and assumptions continually, using evidence as the basis for iteration (Standard 7: Iterate and improve frequently)](7-iterate-improve-frequently.md#user-content-74-start-small-and-test-designs-and-assumptions-continually-using-evidence-as-the-basis-for-iteration)
+- [8.2 Assess the full impact on users and communities (Standard 8: Design ethical services)](8-design-ethical-services.md#user-content-82-assess-the-full-impact-on-users-and-communities)
+- [8.4 Balance trade-offs between innovation and inclusiveness (Standard 8: Design ethical services)](8-design-ethical-services.md#user-content-84-balance-trade-offs-between-innovation-and-inclusiveness)
+- [10.1 Collect data once to avoid duplication (Standard 10: Be good data stewards)](10-be-good-data-stewards.md#user-content-101-collect-data-once-to-avoid-duplication)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.1 Build nothing for the user, without the user being involved
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 Focus on the needs of your users, using agile, iterative and user-centred methods when building a service. Start with extensive research and analysis to help understand who is using the service, what their needs are and how the service will affect their lives to better understand how the service should be designed. The absence of the user voice leads to assumptions that may be incorrect and costly.
 
@@ -73,7 +50,7 @@ Users should be involved throughout the lifecycle of the service, with user rese
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -99,7 +76,7 @@ Users should be involved throughout the lifecycle of the service, with user rese
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -107,7 +84,7 @@ Users should be involved throughout the lifecycle of the service, with user rese
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -116,23 +93,23 @@ Users should be involved throughout the lifecycle of the service, with user rese
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 User needs are constantly evolving which it is why it is important to plan for ongoing user research and usability testing. Engage users at all stages, continuously seeking feedback to ensure the service helps users to accomplish their tasks and to keep improving the service to better meet user needs.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
 **[TODO: Add/revise checklist items]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -146,7 +123,7 @@ User needs are constantly evolving which it is why it is important to plan for o
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Beta and live stages
 
@@ -169,7 +146,7 @@ User needs are constantly evolving which it is why it is important to plan for o
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -177,7 +154,7 @@ User needs are constantly evolving which it is why it is important to plan for o
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -186,17 +163,17 @@ User needs are constantly evolving which it is why it is important to plan for o
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.3 Understand the context in which people are interacting and design appropriate solutions that meet their needs
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 A key part of building digital services that work for users is developing a good understanding of who are the users, what are their needs and how the service will affect their lives. It is equally important to develop a good understanding of the different contexts in which users could be interacting, since user needs and expectations can vary depending upon where, when and how they use a digital service.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -205,7 +182,7 @@ A key part of building digital services that work for users is developing a good
 - Clearly defined user needs **(Build It Right - OneGC Architectural Checklist (draft))**
   - User research, requirements and usability testing must be incorporated and tracked from the very beginning of any digital project
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -233,7 +210,7 @@ A key part of building digital services that work for users is developing a good
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -267,7 +244,7 @@ A key part of building digital services that work for users is developing a good
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -284,7 +261,7 @@ A key part of building digital services that work for users is developing a good
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -328,7 +305,7 @@ A key part of building digital services that work for users is developing a good
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -345,18 +322,18 @@ A key part of building digital services that work for users is developing a good
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.4 Clearly articulate and understand the end-to-end problem and use data to demonstrate that it is being solved
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 We need to understand the different ways people will interact with our services, including the actions they take online, through a mobile application, on a phone, or in person. Every encounter --- whether it's online or offline --- should move the user closer towards their goal. **(Digital Services Playbook (US))**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -372,7 +349,7 @@ We need to understand the different ways people will interact with our services,
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -380,7 +357,7 @@ We need to understand the different ways people will interact with our services,
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -389,17 +366,17 @@ We need to understand the different ways people will interact with our services,
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline dpgn-phase-alpha">
+<section class="dpgn-section-guideline dpgn-phase-alpha">
 
 ## 1.5 Provide services that can be obtained anytime, anywhere and on any device
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -412,7 +389,7 @@ We need to understand the different ways people will interact with our services,
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -420,7 +397,7 @@ We need to understand the different ways people will interact with our services,
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -429,11 +406,11 @@ We need to understand the different ways people will interact with our services,
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.6 Make services simple, intuitive and consistent
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -455,7 +432,7 @@ Writing and designing content so it is consistent, plain and in the language of 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -505,7 +482,7 @@ Writing and designing content so it is consistent, plain and in the language of 
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -529,7 +506,7 @@ Writing and designing content so it is consistent, plain and in the language of 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -548,11 +525,11 @@ Writing and designing content so it is consistent, plain and in the language of 
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.7 Make it more convenient and practical to use digital services
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -586,13 +563,13 @@ We still need to help users who are unable to use digital channels and provide s
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
 **[TODO: Add/revise checklist items]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -630,7 +607,7 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -652,7 +629,7 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -674,7 +651,7 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Beta and live stages
 
@@ -687,7 +664,7 @@ We still need to help users who are unable to use digital channels and provide s
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -701,7 +678,7 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -715,11 +692,11 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.8 Support people who cannot use digital services on their own
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -733,7 +710,7 @@ You need to have a plan for what to do if your service goes offline so that you 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -759,7 +736,7 @@ You need to have a plan for what to do if your service goes offline so that you 
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -771,7 +748,7 @@ You need to have a plan for what to do if your service goes offline so that you 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 

--- a/en/10-be-good-data-stewards.md
+++ b/en/10-be-good-data-stewards.md
@@ -15,8 +15,10 @@ altLangPage: 10-soyez-bons-gestionnaires-donnees
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/en/10-be-good-data-stewards.md
+++ b/en/10-be-good-data-stewards.md
@@ -5,65 +5,48 @@ lang: en
 altLang: fr
 altLangPage: 10-soyez-bons-gestionnaires-donnees
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[10.1 Collect data once to avoid duplication](#user-content-101-collect-data-once-to-avoid-duplication)
-
-[10.2 Make relevant government information and data easily accessible to help support decision making](#user-content-102-make-relevant-government-information-and-data-easily-accessible-to-help-support-decision-making)
-
-[10.3 Ensure that data is collected in a standard way so that it can easily be integrated and reused by others](#user-content-103-ensure-that-data-is-collected-in-a-standard-way-so-that-it-can-easily-be-integrated-and-reused-by-others)
-
-[10.4 Give due consideration to digital preservation and retention](#user-content-104-give-due-consideration-to-digital-preservation-and-retention)
-
-[10.5 Ensure data and information is complete, accurate and up-to-date](#user-content-105-ensure-data-and-information-is-complete-accurate-and-up-to-date)
-
-[10.6 Ensure data is well-structured, intuitive and in a format that is easy to integrate and reuse by others](#user-content-106-ensure-data-is-well-structured-intuitive-and-in-a-format-that-is-easy-to-integrate-and-reuse-by-others)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[1.4 Clearly articulate and understand the end-to-end problem and use data to demonstrate that it is being solved (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-14-clearly-articulate-and-understand-the-end-to-end-problem-and-use-data-to-demonstrate-that-it-is-being-solved)
-
-[5.1 Make all non-sensitive data and information open to the outside world for sharing and reuse under an open licence (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-51-make-all-non-sensitive-data-and-information-open-to-the-outside-world-for-sharing-and-reuse-under-an-open-licence)
-
-[5.2 Be transparent with goals and publish real-time performance data (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-52-be-transparent-with-goals-and-publish-real-time-performance-data)
-
-[5.3 Measure and monitor the effectiveness, value, and consequences of your service and report publicly (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-53-measure-and-monitor-the-effectiveness-value-and-consequences-of-your-service-and-report-publicly)
-
-[5.4 Be transparent about how you work and justify the decisions you make (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-54-be-transparent-about-how-you-work-and-justify-the-decisions-you-make)
-
-[6.1 Leverage open standards and embrace leading practices (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-61-leverage-open-standards-and-embrace-leading-practices)
-
-[6.2 Use and reuse common, proven government solutions, approaches, and platforms (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-62-use-and-reuse-common-proven-government-solutions-approaches-and-platforms)
-
-[6.4 Open up the data, transactions, and business rules that underpin a service (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-64-open-up-the-data-transactions-and-business-rules-that-underpin-a-service)
-
-[9.2 Innovate and improve while meeting the public's expectation that their data privacy will be protected (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-92-innovate-and-improve-while-meeting-the-publics-expectation-that-their-data-privacy-will-be-protected)
+- [1.4 Clearly articulate and understand the end-to-end problem and use data to demonstrate that it is being solved (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-14-clearly-articulate-and-understand-the-end-to-end-problem-and-use-data-to-demonstrate-that-it-is-being-solved)
+- [5.1 Make all non-sensitive data and information open to the outside world for sharing and reuse under an open licence (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-51-make-all-non-sensitive-data-and-information-open-to-the-outside-world-for-sharing-and-reuse-under-an-open-licence)
+- [5.2 Be transparent with goals and publish real-time performance data (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-52-be-transparent-with-goals-and-publish-real-time-performance-data)
+- [5.3 Measure and monitor the effectiveness, value, and consequences of your service and report publicly (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-53-measure-and-monitor-the-effectiveness-value-and-consequences-of-your-service-and-report-publicly)
+- [5.4 Be transparent about how you work and justify the decisions you make (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-54-be-transparent-about-how-you-work-and-justify-the-decisions-you-make)
+- [6.1 Leverage open standards and embrace leading practices (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-61-leverage-open-standards-and-embrace-leading-practices)
+- [6.2 Use and reuse common, proven government solutions, approaches, and platforms (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-62-use-and-reuse-common-proven-government-solutions-approaches-and-platforms)
+- [6.4 Open up the data, transactions, and business rules that underpin a service (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-64-open-up-the-data-transactions-and-business-rules-that-underpin-a-service)
+- [9.2 Innovate and improve while meeting the public's expectation that their data privacy will be protected (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-92-innovate-and-improve-while-meeting-the-publics-expectation-that-their-data-privacy-will-be-protected)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.1 Collect data once to avoid duplication
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -71,7 +54,7 @@ altLangPage: 10-soyez-bons-gestionnaires-donnees
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -80,11 +63,11 @@ altLangPage: 10-soyez-bons-gestionnaires-donnees
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.2 Make relevant government information and data easily accessible to help support decision making
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -92,7 +75,7 @@ At every stage of a project, we should measure how well our service is working f
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -116,7 +99,7 @@ At every stage of a project, we should measure how well our service is working f
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -132,7 +115,7 @@ At every stage of a project, we should measure how well our service is working f
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -141,11 +124,11 @@ At every stage of a project, we should measure how well our service is working f
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.3 Ensure that data is collected in a standard way so that it can easily be integrated and reused by others
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -175,13 +158,13 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
 **[TODO: Add/revise checklist items]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Alpha, beta and live stages
 
@@ -215,7 +198,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -231,7 +214,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -249,7 +232,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -283,7 +266,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -311,7 +294,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -324,17 +307,17 @@ Every service must aim for continuous improvement. Metrics are an important star
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.4 Give due consideration to digital preservation and retention
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -342,7 +325,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -364,17 +347,17 @@ Every service must aim for continuous improvement. Metrics are an important star
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.5 Ensure data and information is complete, accurate and up-to-date
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -386,7 +369,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -408,17 +391,17 @@ Every service must aim for continuous improvement. Metrics are an important star
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.6 Ensure data is well-structured, intuitive and in a format that is easy to integrate and reuse by others
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -432,7 +415,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 

--- a/en/2-build-in-accessibility-from-start.md
+++ b/en/2-build-in-accessibility-from-start.md
@@ -15,8 +15,10 @@ altLangPage: 2-construire-dans-accessibilite-des-debut
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/en/2-build-in-accessibility-from-start.md
+++ b/en/2-build-in-accessibility-from-start.md
@@ -5,51 +5,40 @@ lang: en
 altLang: fr
 altLangPage: 2-construire-dans-accessibilite-des-debut
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[2.1 Build for those with the greatest needs and it will work for everyone else](#user-content-21-build-for-those-with-the-greatest-needs-and-it-will-work-for-everyone-else)
-
-[2.2 Services should meet or exceed accessibility standards, and should not feel burdensome to use](#user-content-22-services-should-meet-or-exceed-accessibility-standards-and-should-not-feel-burdensome-to-use)
-
-[2.3 Co-create with people who have distinct needs, being inclusive from the very beginning](#user-content-23-co-create-with-people-who-have-distinct-needs-being-inclusive-from-the-very-beginning)
-
-[2.4 Take into consideration a user's possible constraints when designing services](#user-content-24-take-into-consideration-a-users-possible-constraints-when-designing-services)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[1.1 Build nothing for the user, without the user being involved (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-11-build-nothing-for-the-user-without-the-user-being-involved)
-
-[1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-12-empathize-with-the-people-using-the-service-and-have-them-engaged-at-all-stages-from-planning-to-ongoing-improvements)
-
-[1.3 Understand the context in which people are interacting and design appropriate solutions that meet their needs (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-13-understand-the-context-in-which-people-are-interacting-and-design-appropriate-solutions-that-meet-their-needs)
-
-[1.5 Provide services that can be obtained anytime, anywhere and on any device (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-15-provide-services-that-can-be-obtained-anytime-anywhere-and-on-any-device)
-
-[1.6 Make services simple, intuitive and consistent (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-16-make-services-simple-intuitive-and-consistent)
-
-[1.8 Support people who cannot use digital services on their own (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-18-support-people-who-cannot-use-digital-services-on-their-own)
-
-[8.4 Balance trade-offs between innovation and inclusiveness (Standard&#160;8: Design ethical services)](8-design-ethical-services.md#user-content-84-balance-trade-offs-between-innovation-and-inclusiveness)
+- [1.1 Build nothing for the user, without the user being involved (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-11-build-nothing-for-the-user-without-the-user-being-involved)
+- [1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-12-empathize-with-the-people-using-the-service-and-have-them-engaged-at-all-stages-from-planning-to-ongoing-improvements)
+- [1.3 Understand the context in which people are interacting and design appropriate solutions that meet their needs (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-13-understand-the-context-in-which-people-are-interacting-and-design-appropriate-solutions-that-meet-their-needs)
+- [1.5 Provide services that can be obtained anytime, anywhere and on any device (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-15-provide-services-that-can-be-obtained-anytime-anywhere-and-on-any-device)
+- [1.6 Make services simple, intuitive and consistent (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-16-make-services-simple-intuitive-and-consistent)
+- [1.8 Support people who cannot use digital services on their own (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-18-support-people-who-cannot-use-digital-services-on-their-own)
+- [8.4 Balance trade-offs between innovation and inclusiveness (Standard&#160;8: Design ethical services)](8-design-ethical-services.md#user-content-84-balance-trade-offs-between-innovation-and-inclusiveness)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 2.1 Build for those with the greatest needs and it will work for everyone else
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 The Government of Canada is committed to ensuring that a high level of accessibility is applied uniformly across its service delivery channels. Technologies and standards are constantly evolving and accessibility plays a major role in making the Government of Canada more effective and inclusive. A more consistent, convenient, clear, and easy user experience when using government services online builds trust.
 
@@ -57,7 +46,7 @@ Development of accessible (regardless of ability, device or environment) digital
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -79,7 +68,7 @@ Development of accessible (regardless of ability, device or environment) digital
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -107,13 +96,13 @@ Development of accessible (regardless of ability, device or environment) digital
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 2.2 Services should meet or exceed accessibility standards, and should not feel burdensome to use
 
 **[TODO: Add/revise introductory text]**
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 Accessibility is not only required by law, it's also good design. Creating fully accessible digital products and services improves the experience for everybody. Ensure the service is accessible to all users regardless of their individual abilities, device or environment.
 
@@ -131,7 +120,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -161,7 +150,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 - make sure your staff will be equipped with knowledge of barriers to accessibility and will be trained to assist users with disabilities in completing tasks and accessing information **(Digital Service Standard (Ontario))**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -183,7 +172,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -219,7 +208,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -237,7 +226,7 @@ Your service must be accessible to users regardless of their digital confidence 
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -266,7 +255,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -277,11 +266,11 @@ Your service must be accessible to users regardless of their digital confidence 
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 2.3 Co-create with people who have distinct needs, being inclusive from the very beginning
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -301,7 +290,7 @@ This applies when designing and developing:
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -356,7 +345,7 @@ For browsers, media players, and other 'user agents', follow User Agent Accessib
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -386,11 +375,11 @@ For browsers, media players, and other 'user agents', follow User Agent Accessib
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 2.4 Take into consideration a user's possible constraints when designing services
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -404,7 +393,7 @@ Until you consider the needs of the range of people that will be using your serv
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -503,7 +492,7 @@ Until you consider the needs of the range of people that will be using your serv
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 

--- a/en/3-collaborate-widely.md
+++ b/en/3-collaborate-widely.md
@@ -15,8 +15,10 @@ altLangPage: 3-collaborez-largement
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/en/3-collaborate-widely.md
+++ b/en/3-collaborate-widely.md
@@ -5,45 +5,37 @@ lang: en
 altLang: fr
 altLangPage: 3-collaborez-largement
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[3.1 Empower multidisciplinary teams with diverse perspectives and skills](#user-content-31-empower-multidisciplinary-teams-with-diverse-perspectives-and-skills)
-
-[3.2 Recognize that an organization can't have all the best ideas, create partnerships and collaborate with a diverse range of partners](#user-content-32-recognize-that-an-organization-cant-have-all-the-best-ideas-create-partnerships-and-collaborate-with-a-diverse-range-of-partners)
-
-[3.3 Build the capacity to dynamically pull in new partners for co-innovation](#user-content-33-build-the-capacity-to-dynamically-pull-in-new-partners-for-co-innovation)
-
-[3.4 Share and collaborate in the open, link to the work of others, and provide resources that others can reuse](#user-content-34-share-and-collaborate-in-the-open-link-to-the-work-of-others-and-provide-resources-that-others-can-reuse)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[1.1 Build nothing for the user, without the user being involved (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-11-build-nothing-for-the-user-without-the-user-being-involved)
-
-[1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-12-empathize-with-the-people-using-the-service-and-have-them-engaged-at-all-stages-from-planning-to-ongoing-improvements)
-
-[2.3 Co-create with people who have distinct needs, being inclusive from the very beginning (Standard&#160;2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-23-co-create-with-people-who-have-distinct-needs-being-inclusive-from-the-very-beginning)
-
-[5.5 Work in the open and make source code open and reusable (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-55-work-in-the-open-and-make-source-code-open-and-reusable)
+- [1.1 Build nothing for the user, without the user being involved (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-11-build-nothing-for-the-user-without-the-user-being-involved)
+- [1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-12-empathize-with-the-people-using-the-service-and-have-them-engaged-at-all-stages-from-planning-to-ongoing-improvements)
+- [2.3 Co-create with people who have distinct needs, being inclusive from the very beginning (Standard&#160;2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-23-co-create-with-people-who-have-distinct-needs-being-inclusive-from-the-very-beginning)
+- [5.5 Work in the open and make source code open and reusable (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-55-work-in-the-open-and-make-source-code-open-and-reusable)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 3.1 Empower multidisciplinary teams with diverse perspectives and skills
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -73,7 +65,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -141,7 +133,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -159,7 +151,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -174,17 +166,17 @@ Good government services are built quickly and iteratively, based on user needs.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 3.2 Recognize that an organization can't have all the best ideas, create partnerships and collaborate with a diverse range of partners
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -210,7 +202,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -230,17 +222,17 @@ Good government services are built quickly and iteratively, based on user needs.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 3.3 Build the capacity to dynamically pull in new partners for co-innovation
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -248,7 +240,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -257,11 +249,11 @@ Good government services are built quickly and iteratively, based on user needs.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 3.4 Share and collaborate in the open, link to the work of others, and provide resources that others can reuse
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -271,7 +263,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -289,7 +281,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 - Link to the work of others
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -307,7 +299,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -315,7 +307,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -340,7 +332,7 @@ Good government services are built quickly and iteratively, based on user needs.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -362,7 +354,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 

--- a/en/4-empower-staff-deliver-better-services.md
+++ b/en/4-empower-staff-deliver-better-services.md
@@ -15,8 +15,10 @@ altLangPage: 4-habiliter-personnel-fournir-meilleurs-services
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/en/4-empower-staff-deliver-better-services.md
+++ b/en/4-empower-staff-deliver-better-services.md
@@ -5,67 +5,50 @@ lang: en
 altLang: fr
 altLangPage: 4-habiliter-personnel-fournir-meilleurs-services
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[4.1 Provide ongoing training and learning opportunities to continually improve the skills of the team and the broader network](#user-content-41-provide-ongoing-training-and-learning-opportunities-to-continually-improve-the-skills-of-the-team-and-the-broader-network)
-
-[4.2 Make sure that staff have access to the tools and technologies they need to be innovative](#user-content-42-make-sure-that-staff-have-access-to-the-tools-and-technologies-they-need-to-be-innovative)
-
-[4.3 Ensure that the right systems and processes are in place so the team can create](#user-content-43-ensure-that-the-right-systems-and-processes-are-in-place-so-the-team-can-create)
-
-[4.4 Empower teams to make decisions throughout the design, build, and operation of the service and allow them to learn from their mistakes](#user-content-44-empower-teams-to-make-decisions-throughout-the-design-build-and-operation-of-the-service-and-allow-them-to-learn-from-their-mistakes)
-
-[4.5 Make one person accountable for the service](#user-content-45-make-one-person-accountable-for-the-service)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[3.1 Empower multidisciplinary teams with diverse perspectives and skills (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-31-empower-multidisciplinary-teams-with-diverse-perspectives-and-skills)
-
-[3.2 Recognize that an organization can't have all the best ideas, create partnerships and collaborate with a diverse range of partners (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-32-recognize-that-an-organization-cant-have-all-the-best-ideas-create-partnerships-and-collaborate-with-a-diverse-range-of-partners)
-
-[3.3 Build the capacity to dynamically pull in new partners for co-innovation (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-33-build-the-capacity-to-dynamically-pull-in-new-partners-for-co-innovation)
-
-[5.4 Be transparent about how you work and justify the decisions you make (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-54-be-transparent-about-how-you-work-and-justify-the-decisions-you-make)
-
-[5.5 Work in the open and make source code open and reusable (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-55-work-in-the-open-and-make-source-code-open-and-reusable)
-
-[6.1 Leverage open standards and embrace leading practices (Standard&#160;6: Use open standards and solutions](6-use-open-standards-solutions.md#user-content-61-leverage-open-standards-and-embrace-leading-practices)
-
-[6.2 Use and reuse common, proven government solutions, approaches, and platforms (Standard&#160;6: Use open standards and solutions](6-use-open-standards-solutions.md#user-content-62-use-and-reuse-common-proven-government-solutions-approaches-and-platforms)
-
-[7.1 Build in an agile manner and continuously improve in response to user needs (Standard&#160;7: Iterate and improve frequently](7-iterate-improve-frequently.md#user-content-71-build-in-an-agile-manner-and-continuously-improve-in-response-to-user-needs)
-
-[7.2 Accept that change is inevitable and use adaptive strategies and tools for new development (Standard&#160;7: Iterate and improve frequently](7-iterate-improve-frequently.md#user-content-72-accept-that-change-is-inevitable-and-use-adaptive-strategies-and-tools-for-new-development)
-
-[7.3 Embrace and react to changes in the environment and design for sustainability (Standard&#160;7: Iterate and improve frequently](7-iterate-improve-frequently.md#user-content-73-embrace-and-react-to-changes-in-the-environment-and-design-for-sustainability)
-
-[7.4 Start small and test designs and assumptions continually, using evidence as the basis for iteration (Standard&#160;7: Iterate and improve frequently](7-iterate-improve-frequently.md#user-content-74-start-small-and-test-designs-and-assumptions-continually-using-evidence-as-the-basis-for-iteration)
+- [3.1 Empower multidisciplinary teams with diverse perspectives and skills (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-31-empower-multidisciplinary-teams-with-diverse-perspectives-and-skills)
+- [3.2 Recognize that an organization can't have all the best ideas, create partnerships and collaborate with a diverse range of partners (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-32-recognize-that-an-organization-cant-have-all-the-best-ideas-create-partnerships-and-collaborate-with-a-diverse-range-of-partners)
+- [3.3 Build the capacity to dynamically pull in new partners for co-innovation (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-33-build-the-capacity-to-dynamically-pull-in-new-partners-for-co-innovation)
+- [5.4 Be transparent about how you work and justify the decisions you make (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-54-be-transparent-about-how-you-work-and-justify-the-decisions-you-make)
+- [5.5 Work in the open and make source code open and reusable (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-55-work-in-the-open-and-make-source-code-open-and-reusable)
+- [6.1 Leverage open standards and embrace leading practices (Standard&#160;6: Use open standards and solutions](6-use-open-standards-solutions.md#user-content-61-leverage-open-standards-and-embrace-leading-practices)
+- [6.2 Use and reuse common, proven government solutions, approaches, and platforms (Standard&#160;6: Use open standards and solutions](6-use-open-standards-solutions.md#user-content-62-use-and-reuse-common-proven-government-solutions-approaches-and-platforms)
+- [7.1 Build in an agile manner and continuously improve in response to user needs (Standard&#160;7: Iterate and improve frequently](7-iterate-improve-frequently.md#user-content-71-build-in-an-agile-manner-and-continuously-improve-in-response-to-user-needs)
+- [7.2 Accept that change is inevitable and use adaptive strategies and tools for new development (Standard&#160;7: Iterate and improve frequently](7-iterate-improve-frequently.md#user-content-72-accept-that-change-is-inevitable-and-use-adaptive-strategies-and-tools-for-new-development)
+- [7.3 Embrace and react to changes in the environment and design for sustainability (Standard&#160;7: Iterate and improve frequently](7-iterate-improve-frequently.md#user-content-73-embrace-and-react-to-changes-in-the-environment-and-design-for-sustainability)
+- [7.4 Start small and test designs and assumptions continually, using evidence as the basis for iteration (Standard&#160;7: Iterate and improve frequently](7-iterate-improve-frequently.md#user-content-74-start-small-and-test-designs-and-assumptions-continually-using-evidence-as-the-basis-for-iteration)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.1 Provide ongoing training and learning opportunities to continually improve the skills of the team and the broader network
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -73,7 +56,7 @@ altLangPage: 4-habiliter-personnel-fournir-meilleurs-services
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -82,11 +65,11 @@ altLangPage: 4-habiliter-personnel-fournir-meilleurs-services
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.2 Make sure that staff have access to the tools and technologies they need to be innovative
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -117,7 +100,7 @@ The technology you choose to build your service must help you respond quickly an
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -125,7 +108,7 @@ The technology you choose to build your service must help you respond quickly an
 
 - Ensure the project team has a modern workplace, professional development and the IM-IT tools they need to do their jobs
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -157,7 +140,7 @@ The technology you choose to build your service must help you respond quickly an
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -185,7 +168,7 @@ The technology you choose to build your service must help you respond quickly an
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -210,7 +193,7 @@ The technology you choose to build your service must help you respond quickly an
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -220,7 +203,7 @@ The technology you choose to build your service must help you respond quickly an
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -231,11 +214,11 @@ The technology you choose to build your service must help you respond quickly an
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.3 Ensure that the right systems and processes are in place so the team can create
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -245,7 +228,7 @@ It is essential that business processes be reviewed to identify opportunities to
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -285,7 +268,7 @@ It is essential that business processes be reviewed to identify opportunities to
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -293,7 +276,7 @@ It is essential that business processes be reviewed to identify opportunities to
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -304,11 +287,11 @@ It is essential that business processes be reviewed to identify opportunities to
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.4 Empower teams to make decisions throughout the design, build, and operation of the service and allow them to learn from their mistakes
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -321,7 +304,7 @@ Working to create an environment that empowers employees has been shown to not o
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -345,7 +328,7 @@ Working to create an environment that empowers employees has been shown to not o
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -354,11 +337,11 @@ Working to create an environment that empowers employees has been shown to not o
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.5 Make one person accountable for the service
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -366,7 +349,7 @@ Each service must have one person who has the authority and is responsibile for 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -394,7 +377,7 @@ Each service must have one person who has the authority and is responsibile for 
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -402,7 +385,7 @@ Each service must have one person who has the authority and is responsibile for 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 

--- a/en/5-work-in-open-by-default.md
+++ b/en/5-work-in-open-by-default.md
@@ -15,8 +15,10 @@ altLangPage: 5-travailler-air-libre-par-defaut
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/en/5-work-in-open-by-default.md
+++ b/en/5-work-in-open-by-default.md
@@ -5,55 +5,44 @@ lang: en
 altLang: fr
 altLangPage: 5-travailler-air-libre-par-defaut
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[5.1 Make all non-sensitive data and information open to the outside world for sharing and reuse under an open licence](#user-content-51-make-all-non-sensitive-data-and-information-open-to-the-outside-world-for-sharing-and-reuse-under-an-open-licence)
-
-[5.2 Be transparent with goals and publish real-time performance data](#user-content-52-be-transparent-with-goals-and-publish-real-time-performance-data)
-
-[5.3 Measure and monitor the effectiveness, value, and consequences of your service and report publicly](#user-content-53-measure-and-monitor-the-effectiveness-value-and-consequences-of-your-service-and-report-publicly)
-
-[5.4 Be transparent about how you work and justify the decisions you make](#user-content-54-be-transparent-about-how-you-work-and-justify-the-decisions-you-make)
-
-[5.5 Work in the open and make source code open and reusable](#user-content-55-work-in-the-open-and-make-source-code-open-and-reusable)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[3.4 Share and collaborate in the open, link to the work of others, and provide resources that others can reuse (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-34-share-and-collaborate-in-the-open-link-to-the-work-of-others-and-provide-resources-that-others-can-reuse)
-
-[6.3 Design for interoperability, allowing services to be discovered and leveraged by the community (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-63-design-for-interoperability-allowing-services-to-be-discovered-and-leveraged-by-the-community)
-
-[6.4 Open up the data, transactions, and business rules that underpin a service (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-64-open-up-the-data-transactions-and-business-rules-that-underpin-a-service)
-
-[8.1 Be transparent about personal and organizational biases and indicate how they are being addressed (Standard&#160;8: Design ethical services)](8-design-ethical-services.md#user-content-81-be-transparent-about-personal-and-organizational-biases-and-indicate-how-they-are-being-addressed)
-
-[10.2 Make relevant government information and data easily accessible to help support decision making (Standard&#160;10: Be good data stewards)](10-be-good-data-stewards.md#user-content-102-make-relevant-government-information-and-data-easily-accessible-to-help-support-decision-making)
+- [3.4 Share and collaborate in the open, link to the work of others, and provide resources that others can reuse (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-34-share-and-collaborate-in-the-open-link-to-the-work-of-others-and-provide-resources-that-others-can-reuse)
+- [6.3 Design for interoperability, allowing services to be discovered and leveraged by the community (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-63-design-for-interoperability-allowing-services-to-be-discovered-and-leveraged-by-the-community)
+- [6.4 Open up the data, transactions, and business rules that underpin a service (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-64-open-up-the-data-transactions-and-business-rules-that-underpin-a-service)
+- [8.1 Be transparent about personal and organizational biases and indicate how they are being addressed (Standard&#160;8: Design ethical services)](8-design-ethical-services.md#user-content-81-be-transparent-about-personal-and-organizational-biases-and-indicate-how-they-are-being-addressed)
+- [10.2 Make relevant government information and data easily accessible to help support decision making (Standard&#160;10: Be good data stewards)](10-be-good-data-stewards.md#user-content-102-make-relevant-government-information-and-data-easily-accessible-to-help-support-decision-making)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.1 Make all non-sensitive data and information open to the outside world for sharing and reuse under an open licence
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -73,7 +62,7 @@ altLangPage: 5-travailler-air-libre-par-defaut
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -86,17 +75,17 @@ altLangPage: 5-travailler-air-libre-par-defaut
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.2 Be transparent with goals and publish real-time performance data
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -104,7 +93,7 @@ altLangPage: 5-travailler-air-libre-par-defaut
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -113,11 +102,11 @@ altLangPage: 5-travailler-air-libre-par-defaut
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.3 Measure and monitor the effectiveness, value, and consequences of your service and report publicly
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -133,13 +122,13 @@ Setting performance indicators allows you to continuously improve your service b
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
 **[TODO: Add/revise checklist items]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Alpha, beta and live stages
 
@@ -165,7 +154,7 @@ Setting performance indicators allows you to continuously improve your service b
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -174,7 +163,7 @@ Setting performance indicators allows you to continuously improve your service b
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -194,7 +183,7 @@ Setting performance indicators allows you to continuously improve your service b
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -203,11 +192,11 @@ Setting performance indicators allows you to continuously improve your service b
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.4 Be transparent about how you work and justify the decisions you make
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -215,7 +204,7 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -239,7 +228,7 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -247,7 +236,7 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -258,11 +247,11 @@ Share your experiences with colleagues across the Government of Canada, other le
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.5 Work in the open and make source code open and reusable
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -296,7 +285,7 @@ Open source helps to:
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -316,7 +305,7 @@ Open source helps to:
   - Actively use and contribute to open source tools and solutions
   - Develop in the open by sharing and reusing all types of code and platform configuration
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -334,7 +323,7 @@ Open source helps to:
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -342,7 +331,7 @@ Open source helps to:
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -367,7 +356,7 @@ Open source helps to:
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -389,7 +378,7 @@ Open source helps to:
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 

--- a/en/6-use-open-standards-solutions.md
+++ b/en/6-use-open-standards-solutions.md
@@ -5,51 +5,38 @@ lang: en
 altLang: fr
 altLangPage: 6-utiliser-standards-solutions-ouverts
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[6.1 Leverage open standards and embrace leading practices](#user-content-61-leverage-open-standards-and-embrace-leading-practices)
-
-[6.2 Use and reuse common, proven government solutions, approaches, and platforms](#user-content-62-use-and-reuse-common-proven-government-solutions-approaches-and-platforms)
-
-[6.3 Design for interoperability, allowing services to be discovered and leveraged by the community](#user-content-63-design-for-interoperability-allowing-services-to-be-discovered-and-leveraged-by-the-community)
-
-[6.4 Open up the data, transactions, and business rules that underpin a service](#user-content-64-open-up-the-data-transactions-and-business-rules-that-underpin-a-service)
-
-[6.5 Design, build and test end-to-end digital services](#user-content-65-design-build-and-test-end-to-end-digital-services)
-
-[6.6 Cloud first](#user-content-66-cloud-first)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[1.5 Provide services that can be obtained anytime, anywhere and on any device (Standard 1: Design with users)](1-design-with-users.md#user-content-15-provide-services-that-can-be-obtained-anytime-anywhere-and-on-any-device)
-
-[3.4 Share and collaborate in the open, link to the work of others, and provide resources that others can reuse (Standard 3: Collaborate widely)](3-collaborate-widely.md#user-content-34-share-and-collaborate-in-the-open-link-to-the-work-of-others-and-provide-resources-that-others-can-reuse)
-
-[5.1 Make all non-sensitive data and information open to the outside world for sharing and reuse under an open licence (Standard 5: Work in the open by default)](5-work-in-open-by-default.md#user-content-51-make-all-non-sensitive-data-and-information-open-to-the-outside-world-for-sharing-and-reuse-under-an-open-licence)
-
-[5.5 Work in the open and make source code open and reusable (Standard 5: Work in the open by default)](5-work-in-open-by-default.md#user-content-55-work-in-the-open-and-make-source-code-open-and-reusable)
-
-[10.3 Ensure that data is collected in a standard way so that it can easily be integrated and reused by others (Standard 10: Be good data stewards)](10-be-good-data-stewards.md#user-content-103-ensure-that-data-is-collected-in-a-standard-way-so-that-it-can-easily-be-integrated-and-reused-by-others)
+- [1.5 Provide services that can be obtained anytime, anywhere and on any device (Standard 1: Design with users)](1-design-with-users.md#user-content-15-provide-services-that-can-be-obtained-anytime-anywhere-and-on-any-device)
+- [3.4 Share and collaborate in the open, link to the work of others, and provide resources that others can reuse (Standard 3: Collaborate widely)](3-collaborate-widely.md#user-content-34-share-and-collaborate-in-the-open-link-to-the-work-of-others-and-provide-resources-that-others-can-reuse)
+- [5.1 Make all non-sensitive data and information open to the outside world for sharing and reuse under an open licence (Standard 5: Work in the open by default)](5-work-in-open-by-default.md#user-content-51-make-all-non-sensitive-data-and-information-open-to-the-outside-world-for-sharing-and-reuse-under-an-open-licence)
+- [5.5 Work in the open and make source code open and reusable (Standard 5: Work in the open by default)](5-work-in-open-by-default.md#user-content-55-work-in-the-open-and-make-source-code-open-and-reusable)
+- [10.3 Ensure that data is collected in a standard way so that it can easily be integrated and reused by others (Standard 10: Be good data stewards)](10-be-good-data-stewards.md#user-content-103-ensure-that-data-is-collected-in-a-standard-way-so-that-it-can-easily-be-integrated-and-reused-by-others)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.1 Leverage open standards and embrace leading practices
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -87,7 +74,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -100,7 +87,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 - Use emerging technologies **(Build It Right - OneGC Architectural Checklist (draft))**
   - Leverage new technologies (e.g., AI and blockchain) to shift investments to more modern tec
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -114,7 +101,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Beta and live stages
 
@@ -127,7 +114,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -147,7 +134,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -162,11 +149,11 @@ move between different technologies when you need to, avoiding vendor lock-in.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.2 Use and reuse common, proven government solutions, approaches, and platforms
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -176,7 +163,7 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -231,7 +218,7 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -239,7 +226,7 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -254,11 +241,11 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.3 Design for interoperability, allowing services to be discovered and leveraged by the community
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -268,7 +255,7 @@ Application Program Interfaces (APIs) are a means by which business functionalit
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -292,7 +279,7 @@ Application Program Interfaces (APIs) are a means by which business functionalit
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -307,17 +294,17 @@ Application Program Interfaces (APIs) are a means by which business functionalit
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.4 Open up the data, transactions, and business rules that underpin a service
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -325,7 +312,7 @@ Application Program Interfaces (APIs) are a means by which business functionalit
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -342,11 +329,11 @@ Application Program Interfaces (APIs) are a means by which business functionalit
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.5 Design, build and test end-to-end digital services
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -354,7 +341,7 @@ There are many potential benefits from the greater use of digital services, incl
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -390,7 +377,7 @@ There are many potential benefits from the greater use of digital services, incl
 
 - Conduct load and performance tests at regular intervals, including before public launch **(Digital Services Playbook (US))**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -398,7 +385,7 @@ There are many potential benefits from the greater use of digital services, incl
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Beta and live stages
 
@@ -423,7 +410,7 @@ There are many potential benefits from the greater use of digital services, incl
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -449,7 +436,7 @@ There are many potential benefits from the greater use of digital services, incl
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -466,11 +453,11 @@ There are many potential benefits from the greater use of digital services, incl
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.6 Cloud first
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -495,7 +482,7 @@ Public cloud services offer benefits that enable significant advances in the fol
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -517,7 +504,7 @@ Public cloud services offer benefits that enable significant advances in the fol
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -525,7 +512,7 @@ Public cloud services offer benefits that enable significant advances in the fol
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar ressources
 

--- a/en/6-use-open-standards-solutions.md
+++ b/en/6-use-open-standards-solutions.md
@@ -15,8 +15,10 @@ altLangPage: 6-utiliser-standards-solutions-ouverts
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/en/7-iterate-improve-frequently.md
+++ b/en/7-iterate-improve-frequently.md
@@ -15,8 +15,10 @@ altLangPage: 7-iterer-ameliorer-frequemment
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/en/7-iterate-improve-frequently.md
+++ b/en/7-iterate-improve-frequently.md
@@ -5,43 +5,36 @@ lang: en
 altLang: fr
 altLangPage: 7-iterer-ameliorer-frequemment
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[7.1 Build in an agile manner and continuously improve in response to user needs](#user-content-71-build-in-an-agile-manner-and-continuously-improve-in-response-to-user-needs)
-
-[7.2 Accept that change is inevitable and use adaptive strategies and tools for new development](#user-content-72-accept-that-change-is-inevitable-and-use-adaptive-strategies-and-tools-for-new-development)
-
-[7.3 Embrace and react to changes in the environment and design for sustainability](#user-content-73-embrace-and-react-to-changes-in-the-environment-and-design-for-sustainability)
-
-[7.4 Start small and test designs and assumptions continually, using evidence as the basis for iteration](#user-content-74-start-small-and-test-designs-and-assumptions-continually-using-evidence-as-the-basis-for-iteration)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-12-empathize-with-the-people-using-the-service-and-have-them-engaged-at-all-stages-from-planning-to-ongoing-improvements)
-
-[3.3 Build the capacity to dynamically pull in new partners for co-innovation (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-33-build-the-capacity-to-dynamically-pull-in-new-partners-for-co-innovation)
-
-[9.2 Innovate and improve while meeting the public's expectation that their data privacy will be protected (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-92-innovate-and-improve-while-meeting-the-publics-expectation-that-their-data-privacy-will-be-protected)
+- [1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-12-empathize-with-the-people-using-the-service-and-have-them-engaged-at-all-stages-from-planning-to-ongoing-improvements)
+- [3.3 Build the capacity to dynamically pull in new partners for co-innovation (Standard&#160;3: Collaborate widely)](3-collaborate-widely.md#user-content-33-build-the-capacity-to-dynamically-pull-in-new-partners-for-co-innovation)
+- [9.2 Innovate and improve while meeting the public's expectation that their data privacy will be protected (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-92-innovate-and-improve-while-meeting-the-publics-expectation-that-their-data-privacy-will-be-protected)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 7.1 Build in an agile manner and continuously improve in response to user needs
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -99,7 +92,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -109,7 +102,7 @@ Start with a representation or prototype of the solution that will be tested and
   - Be an agile Developer: Develop in an iterative manner, with key stakeholders participation from the beginning, releasing minimum viable product as soon as possible and iteratively building out functionality
   - Be an agile administrator: Promote DEVOPS and automate, monitor and unify all platform and software construction from testing to release and infrastructure management
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -123,7 +116,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Beta and live stages
 
@@ -135,7 +128,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Alpha, beta and live stages
 
@@ -222,7 +215,7 @@ Start with a representation or prototype of the solution that will be tested and
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -270,7 +263,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar ressources
 
@@ -287,17 +280,17 @@ Start with a representation or prototype of the solution that will be tested and
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 7.2 Accept that change is inevitable and use adaptive strategies and tools for new development
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -305,7 +298,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -314,11 +307,11 @@ Start with a representation or prototype of the solution that will be tested and
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 7.3 Embrace and react to changes in the environment and design for sustainability
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -326,7 +319,7 @@ Once you have designed and launched a service, there is still work to do. Treat 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -340,7 +333,7 @@ Once you have designed and launched a service, there is still work to do. Treat 
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -348,7 +341,7 @@ Once you have designed and launched a service, there is still work to do. Treat 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -357,11 +350,11 @@ Once you have designed and launched a service, there is still work to do. Treat 
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 7.4 Start small and test designs and assumptions continually, using evidence as the basis for iteration
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -379,7 +372,7 @@ You need to build a service which you can iterate and keep improving so that you
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -413,7 +406,7 @@ You need to build a service which you can iterate and keep improving so that you
     - Card Sorting Testing - A reverse tree test where participants sort through items and group them together in a hierarchal manner.
     - First Click Testing - A test that observes the first item that a participant clicks on and uses the selection as an indication as to whether users are directed as intended.
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Alpha, beta and live stages
 
@@ -437,7 +430,7 @@ You need to build a service which you can iterate and keep improving so that you
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -447,7 +440,7 @@ You need to build a service which you can iterate and keep improving so that you
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -458,7 +451,7 @@ You need to build a service which you can iterate and keep improving so that you
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -488,7 +481,7 @@ Find out more about:
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 

--- a/en/8-design-ethical-services.md
+++ b/en/8-design-ethical-services.md
@@ -15,8 +15,10 @@ altLangPage: 8-concevoir-services-ethiques
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/en/8-design-ethical-services.md
+++ b/en/8-design-ethical-services.md
@@ -5,73 +5,54 @@ lang: en
 altLang: fr
 altLangPage: 8-concevoir-services-ethiques
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[8.1 Be transparent about personal and organizational biases and indicate how they are being addressed](#user-content-81-be-transparent-about-personal-and-organizational-biases-and-indicate-how-they-are-being-addressed)
-
-[8.2 Assess the full impact on users and communities](#user-content-82-assess-the-full-impact-on-users-and-communities)
-
-[8.3 Comply with ethical guidelines in the design of automated systems](#user-content-83-comply-with-ethical-guidelines-in-the-design-of-automated-systems)
-
-[8.4 Balance trade-offs between innovation and inclusiveness](#user-content-84-balance-trade-offs-between-innovation-and-inclusiveness)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-12-empathize-with-the-people-using-the-service-and-have-them-engaged-at-all-stages-from-planning-to-ongoing-improvements)
-
-[1.3 Understand the context in which people are interacting and design appropriate solutions that meet their needs (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-13-understand-the-context-in-which-people-are-interacting-and-design-appropriate-solutions-that-meet-their-needs)
-
-[1.4 Clearly articulate and understand the end-to-end problem and use data to demonstrate that it is being solved (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-14-clearly-articulate-and-understand-the-end-to-end-problem-and-use-data-to-demonstrate-that-it-is-being-solved)
-
-[1.8 Support people who cannot use digital services on their own (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-18-support-people-who-cannot-use-digital-services-on-their-own)
-
-[2.1 Build for those with the greatest needs and it will work for everyone else (Standard&#160;2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-21-build-for-those-with-the-greatest-needs-and-it-will-work-for-everyone-else)
-
-[2.2 Services should meet or exceed accessibility standards, and should not feel burdensome to use (Standard&#160;2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-22-services-should-meet-or-exceed-accessibility-standards-and-should-not-feel-burdensome-to-use)
-
-[2.4 Take into consideration a user's possible constraints when designing services (Standard&#160;2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-24-take-into-consideration-a-users-possible-constraints-when-designing-services)
-
-[5.2 Be transparent with goals and publish real-time performance data (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-52-be-transparent-with-goals-and-publish-real-time-performance-data)
-
-[5.3 Measure and monitor the effectiveness, value, and consequences of your service and report publicly (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-53-measure-and-monitor-the-effectiveness-value-and-consequences-of-your-service-and-report-publicly)
-
-[5.4 Be transparent about how you work and justify the decisions you make (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-54-be-transparent-about-how-you-work-and-justify-the-decisions-you-make)
-
-[9.1 Take a balanced approach to managing risk by implementing appropriate privacy and security measures (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-91-take-a-balanced-approach-to-managing-risk-by-implementing-appropriate-privacy-and-security-measures)
-
-[9.2 Innovate and improve while meeting the public's expectation that their data privacy will be protected (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-92-innovate-and-improve-while-meeting-the-publics-expectation-that-their-data-privacy-will-be-protected)
-
-[9.3 Make security seamless and frictionless, balancing security and convenience (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-93-make-security-seamless-and-frictionless-balancing-security-and-convenience)
-
-[9.4 Ensure services comply with all legislated and regulatory requirements (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-94-ensure-services-comply-with-all-legislated-and-regulatory-requirements)
-
-[10.2 Make relevant government information and data easily accessible to help support decision making (Standard&#160;10: Be good data stewards)](10-be-good-data-stewards.md#user-content-102-make-relevant-government-information-and-data-easily-accessible-to-help-support-decision-making)
+- [1.2 Empathize with the people using the service and have them engaged at all stages, from planning to ongoing improvements (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-12-empathize-with-the-people-using-the-service-and-have-them-engaged-at-all-stages-from-planning-to-ongoing-improvements)
+- [1.3 Understand the context in which people are interacting and design appropriate solutions that meet their needs (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-13-understand-the-context-in-which-people-are-interacting-and-design-appropriate-solutions-that-meet-their-needs)
+- [1.4 Clearly articulate and understand the end-to-end problem and use data to demonstrate that it is being solved (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-14-clearly-articulate-and-understand-the-end-to-end-problem-and-use-data-to-demonstrate-that-it-is-being-solved)
+- [1.8 Support people who cannot use digital services on their own (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-18-support-people-who-cannot-use-digital-services-on-their-own)
+- [2.1 Build for those with the greatest needs and it will work for everyone else (Standard&#160;2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-21-build-for-those-with-the-greatest-needs-and-it-will-work-for-everyone-else)
+- [2.2 Services should meet or exceed accessibility standards, and should not feel burdensome to use (Standard&#160;2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-22-services-should-meet-or-exceed-accessibility-standards-and-should-not-feel-burdensome-to-use)
+- [2.4 Take into consideration a user's possible constraints when designing services (Standard&#160;2: Build in accessibility from the start)](2-build-in-accessibility-from-start.md#user-content-24-take-into-consideration-a-users-possible-constraints-when-designing-services)
+- [5.2 Be transparent with goals and publish real-time performance data (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-52-be-transparent-with-goals-and-publish-real-time-performance-data)
+- [5.3 Measure and monitor the effectiveness, value, and consequences of your service and report publicly (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-53-measure-and-monitor-the-effectiveness-value-and-consequences-of-your-service-and-report-publicly)
+- [5.4 Be transparent about how you work and justify the decisions you make (Standard&#160;5: Work in the open by default)](5-work-in-open-by-default.md#user-content-54-be-transparent-about-how-you-work-and-justify-the-decisions-you-make)
+- [9.1 Take a balanced approach to managing risk by implementing appropriate privacy and security measures (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-91-take-a-balanced-approach-to-managing-risk-by-implementing-appropriate-privacy-and-security-measures)
+- [9.2 Innovate and improve while meeting the public's expectation that their data privacy will be protected (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-92-innovate-and-improve-while-meeting-the-publics-expectation-that-their-data-privacy-will-be-protected)
+- [9.3 Make security seamless and frictionless, balancing security and convenience (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-93-make-security-seamless-and-frictionless-balancing-security-and-convenience)
+- [9.4 Ensure services comply with all legislated and regulatory requirements (Standard&#160;9: Address security and privacy risks)](9-address-security-privacy-risks.md#user-content-94-ensure-services-comply-with-all-legislated-and-regulatory-requirements)
+- [10.2 Make relevant government information and data easily accessible to help support decision making (Standard&#160;10: Be good data stewards)](10-be-good-data-stewards.md#user-content-102-make-relevant-government-information-and-data-easily-accessible-to-help-support-decision-making)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 8.1 Be transparent about personal and organizational biases and indicate how they are being addressed
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -79,7 +60,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -88,17 +69,17 @@ altLangPage: 8-concevoir-services-ethiques
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 8.2 Assess the full impact on users and communities
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -106,7 +87,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -115,17 +96,17 @@ altLangPage: 8-concevoir-services-ethiques
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 8.3 Comply with ethical guidelines in the design of automated systems
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -133,7 +114,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -142,17 +123,17 @@ altLangPage: 8-concevoir-services-ethiques
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 8.4 Balance trade-offs between innovation and inclusiveness
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -160,7 +141,7 @@ altLangPage: 8-concevoir-services-ethiques
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 

--- a/en/9-address-security-privacy-risks.md
+++ b/en/9-address-security-privacy-risks.md
@@ -15,8 +15,10 @@ altLangPage: 9-aborder-risques-securite-confidentialite
 
 **Guidelines:**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/en/9-address-security-privacy-risks.md
+++ b/en/9-address-security-privacy-risks.md
@@ -5,57 +5,46 @@ lang: en
 altLang: fr
 altLangPage: 9-aborder-risques-securite-confidentialite
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Guidelines:**
 
-[9.1 Take a balanced approach to managing risk by implementing appropriate privacy and security measures](#user-content-91-take-a-balanced-approach-to-managing-risk-by-implementing-appropriate-privacy-and-security-measures)
-
-[9.2 Innovate and improve while meeting the public's expectation that their data privacy will be protected](#user-content-92-innovate-and-improve-while-meeting-the-publics-expectation-that-their-data-privacy-will-be-protected)
-
-[9.3 Make security seamless and frictionless, balancing security and convenience](#user-content-93-make-security-seamless-and-frictionless-balancing-security-and-convenience)
-
-[9.4 Ensure services comply with all legislated and regulatory requirements](#user-content-94-ensure-services-comply-with-all-legislated-and-regulatory-requirements)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Related guidelines:**
 
-[1.5 Provide services that can be obtained anytime, anywhere and on any device (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-15-provide-services-that-can-be-obtained-anytime-anywhere-and-on-any-device)
-
-[1.6 Make services simple, intuitive and consistent (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-16-make-services-simple-intuitive-and-consistent)
-
-[1.7 Make it more convenient and practical to use digital services (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-17-make-it-more-convenient-and-practical-to-use-digital-services)
-
-[6.1 Leverage open standards and embrace leading practices (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-61-leverage-open-standards-and-embrace-leading-practices)
-
-[6.2 Use and reuse common, proven government solutions, approaches, and platforms (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-62-use-and-reuse-common-proven-government-solutions-approaches-and-platforms)
-
-[8.3 Comply with ethical guidelines in the design of automated systems (Standard&#160;8: Design ethical services)](8-design-ethical-services.md#user-content-83-comply-with-ethical-guidelines-in-the-design-of-automated-systems)
-
-[8.4 Balance trade-offs between innovation and inclusiveness (Standard&#160;8: Design ethical services)](8-design-ethical-services.md#user-content-84-balance-trade-offs-between-innovation-and-inclusiveness)
+- [1.5 Provide services that can be obtained anytime, anywhere and on any device (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-15-provide-services-that-can-be-obtained-anytime-anywhere-and-on-any-device)
+- [1.6 Make services simple, intuitive and consistent (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-16-make-services-simple-intuitive-and-consistent)
+- [1.7 Make it more convenient and practical to use digital services (Standard&#160;1: Design with users)](1-design-with-users.md#user-content-17-make-it-more-convenient-and-practical-to-use-digital-services)
+- [6.1 Leverage open standards and embrace leading practices (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-61-leverage-open-standards-and-embrace-leading-practices)
+- [6.2 Use and reuse common, proven government solutions, approaches, and platforms (Standard&#160;6: Use open standards and solutions)](6-use-open-standards-solutions.md#user-content-62-use-and-reuse-common-proven-government-solutions-approaches-and-platforms)
+- [8.3 Comply with ethical guidelines in the design of automated systems (Standard&#160;8: Design ethical services)](8-design-ethical-services.md#user-content-83-comply-with-ethical-guidelines-in-the-design-of-automated-systems)
+- [8.4 Balance trade-offs between innovation and inclusiveness (Standard&#160;8: Design ethical services)](8-design-ethical-services.md#user-content-84-balance-trade-offs-between-innovation-and-inclusiveness)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 9.1 Take a balanced approach to managing risk by implementing appropriate privacy and security measures
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -65,7 +54,7 @@ altLangPage: 9-aborder-risques-securite-confidentialite
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -78,11 +67,11 @@ altLangPage: 9-aborder-risques-securite-confidentialite
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 9.2 Innovate and improve while meeting the public's expectation that their data privacy will be protected
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -102,13 +91,13 @@ Users won't use a service unless they have a guarantee:
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
 **[TODO: Add/revise checklist items]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -132,7 +121,7 @@ Users won't use a service unless they have a guarantee:
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -145,7 +134,7 @@ Users won't use a service unless they have a guarantee:
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -153,7 +142,7 @@ Users won't use a service unless they have a guarantee:
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -162,11 +151,11 @@ Users won't use a service unless they have a guarantee:
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 9.3 Make security seamless and frictionless, balancing security and convenience
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -186,7 +175,7 @@ Users won't use a service unless they have a guarantee:
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -195,7 +184,7 @@ Users won't use a service unless they have a guarantee:
 - Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
   - Embed all services in Pan-Canadian Trust Framework to foster multi-jurisdictional service delivery
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -225,7 +214,7 @@ Users won't use a service unless they have a guarantee:
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -238,7 +227,7 @@ Users won't use a service unless they have a guarantee:
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -246,7 +235,7 @@ Users won't use a service unless they have a guarantee:
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 
@@ -255,11 +244,11 @@ Users won't use a service unless they have a guarantee:
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 9.4 Ensure services comply with all legislated and regulatory requirements
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **[TODO: Add/revise introductory text]**
 
@@ -292,7 +281,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Checklist
 
@@ -317,7 +306,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 - HTTPS only **(Build It Right - OneGC Architectural Checklist (draft))**
   - Holistic approach to securing GC services for publicly accessible sites
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Alpha stage
 
@@ -360,7 +349,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Beta stage
 
@@ -405,7 +394,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Live stage
 
@@ -434,7 +423,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Implementation guides
 
@@ -452,7 +441,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Similar resources
 

--- a/fr/1-concevoir-avec-utilisateurs.md
+++ b/fr/1-concevoir-avec-utilisateurs.md
@@ -15,8 +15,10 @@ altLangPage: 1-design-with-users
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/fr/1-concevoir-avec-utilisateurs.md
+++ b/fr/1-concevoir-avec-utilisateurs.md
@@ -5,67 +5,44 @@ lang: fr
 altLang: en
 altLangPage: 1-design-with-users
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[1.1 Construire rien pour l'utilisateur, sans que l'utilisateur soit impliqué](#user-content-11-construire-rien-pour-lutilisateur-sans-que-lutilisateur-soit-impliqué)
-
-[1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer](#user-content-12-simpliquer-auprès-des-personnes-qui-ont-le-service-et-le-faire-participer-à-toutes-les-étapes-de-la-planification-à-lamélioration-continuer)
-
-[1.3 Comprendre le contexte dans lequel les gens interagissent et conçoivent des solutions adaptées à leurs besoins](#user-content-13-comprendre-le-contexte-dans-lequel-les-gens-interagissent-et-conçoivent-des-solutions-adaptées-à-leurs-besoins)
-
-[1.4 Clairement articuler and understand the problem of about and use the data for evidence](#user-content-14-clairement-articuler-and-understand-the-problem-of-about-and-use-the-data-for-evidence)
-
-[1.5 Fournir des services qui peuvent être convertis n'importe où, n'importe où et n'importe quel appareil](#user-content-15-fournir-des-services-qui-peuvent-être-tout-quand-et-nimporte-quel-appareil)
-
-[1.6 Rendre les services simples, intuitifs et cohérents](#user-content-16-rendre-les-services-simples-intuitifs-et-cohérents)
-
-[1.7 Rendre plus pratique et pratique l'utilisation des services numériques](#user-content-17-rendre-plus-pratique-et-pratique-lutilisation-des-services-numériques)
-
-[1.8 Soutenir les personnes qui ne peuvent pas utiliser les services numériques par leurs propres moyens](#user-content-18-soutenir-les-personnes-qui-ne-peuvent-pas-utiliser-les-services-numériques-par-leurs-propres-moyens)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
-[2.1 Construire pour ceux qui ont les plus grands besoins et cela fonctionnera pour tout le monde (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-21-construire-pour-ceux-qui-ont-les-plus-grands-besoins-et-cela-fonctionnera-pour-tout-le-monde)
-
-[2.2 Les services devraient respecter ou dépasser les normes d'accessibilité et ne devraient pas être pénibles à utiliser (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-22-les-services-devraient-respecter-ou-dépasser-les-normes-daccessibilité-et-ne-devraient-pas-être-pénibles-à-utiliser)
-
-[2.3 Co-créer avec des personnes ayant des besoins distincts, en étant inclusif dès le début (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-23-co-créer-avec-des-personnes-ayant-des-besoins-distincts-en-étant-inclusif-dès-le-début)
-
-[2.4 Prendre en compte les contraintes possibles d'un utilisateur lors de la conception de services (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-24-prendre-en-compte-les-contraintes-possibles-dun-utilisateur-lors-de-la-conception-de-services)
-
-[3.2 Reconnaître qu'une organisation ne peut pas avoir toutes les meilleures idées, créer des partenariats et collaborer avec un large éventail de partenaires (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-32-reconnaître-quune-organisation-ne-peut-pas-avoir-toutes-les-meilleures-idées-créer-des-partenariats-et-collaborer-avec-un-large-éventail-de-partenaires)
-
-[6.5 Concevoir, créer et tester des services numériques de bout en bout (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-65-concevoir-créer-et-tester-des-services-numériques-de-bout-en-bout)
-
-[7.1 Construire de manière agile et améliorer continuellement en réponse aux besoins des utilisateurs (Norme&#160;7&#160;: Itérer et améliorer fréquemment)](7-iterer-ameliorer-frequemment.md#user-content-71-construire-de-manière-agile-et-améliorer-continuellement-en-réponse-aux-besoins-des-utilisateurs)
-
-[7.4 Commencer petit et tester continuellement les conceptions et les hypothèses, en utilisant les preuves comme base de l'itération (Norme&#160;7&#160;: Itérer et améliorer fréquemment)](7-iterer-ameliorer-frequemment.md#user-content-74-commencer-petit-et-tester-continuellement-les-conceptions-et-les-hypothèses-en-utilisant-les-preuves-comme-base-de-litération)
-
-[8.2 Évaluer l'impact total sur les utilisateurs et les communautés (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-82-Évaluer-limpact-total-sur-les-utilisateurs-et-les-communautés)
-
-[8.4 Équilibrer les compromis entre innovation et inclusivité (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-84-Équilibrer-les-compromis-entre-innovation-et-inclusivité)
-
-[10.1 Collecter les données une fois pour éviter la duplication (Norme&#160;10&#160;: Soyez de bons gestionnaires de données)](10-soyez-bons-gestionnaires-donnees.md#user-content-101-collecter-les-données-une-fois-pour-éviter-la-duplication)
+- [2.1 Construire pour ceux qui ont les plus grands besoins et cela fonctionnera pour tout le monde (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-21-construire-pour-ceux-qui-ont-les-plus-grands-besoins-et-cela-fonctionnera-pour-tout-le-monde)
+- [2.2 Les services devraient respecter ou dépasser les normes d'accessibilité et ne devraient pas être pénibles à utiliser (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-22-les-services-devraient-respecter-ou-dépasser-les-normes-daccessibilité-et-ne-devraient-pas-être-pénibles-à-utiliser)
+- [2.3 Co-créer avec des personnes ayant des besoins distincts, en étant inclusif dès le début (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-23-co-créer-avec-des-personnes-ayant-des-besoins-distincts-en-étant-inclusif-dès-le-début)
+- [2.4 Prendre en compte les contraintes possibles d'un utilisateur lors de la conception de services (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-24-prendre-en-compte-les-contraintes-possibles-dun-utilisateur-lors-de-la-conception-de-services)
+- [3.2 Reconnaître qu'une organisation ne peut pas avoir toutes les meilleures idées, créer des partenariats et collaborer avec un large éventail de partenaires (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-32-reconnaître-quune-organisation-ne-peut-pas-avoir-toutes-les-meilleures-idées-créer-des-partenariats-et-collaborer-avec-un-large-éventail-de-partenaires)
+- [6.5 Concevoir, créer et tester des services numériques de bout en bout (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-65-concevoir-créer-et-tester-des-services-numériques-de-bout-en-bout)
+- [7.1 Construire de manière agile et améliorer continuellement en réponse aux besoins des utilisateurs (Norme&#160;7&#160;: Itérer et améliorer fréquemment)](7-iterer-ameliorer-frequemment.md#user-content-71-construire-de-manière-agile-et-améliorer-continuellement-en-réponse-aux-besoins-des-utilisateurs)
+- [7.4 Commencer petit et tester continuellement les conceptions et les hypothèses, en utilisant les preuves comme base de l'itération (Norme&#160;7&#160;: Itérer et améliorer fréquemment)](7-iterer-ameliorer-frequemment.md#user-content-74-commencer-petit-et-tester-continuellement-les-conceptions-et-les-hypothèses-en-utilisant-les-preuves-comme-base-de-litération)
+- [8.2 Évaluer l'impact total sur les utilisateurs et les communautés (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-82-Évaluer-limpact-total-sur-les-utilisateurs-et-les-communautés)
+- [8.4 Équilibrer les compromis entre innovation et inclusivité (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-84-Équilibrer-les-compromis-entre-innovation-et-inclusivité)
+- [10.1 Collecter les données une fois pour éviter la duplication (Norme&#160;10&#160;: Soyez de bons gestionnaires de données)](10-soyez-bons-gestionnaires-donnees.md#user-content-101-collecter-les-données-une-fois-pour-éviter-la-duplication)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.1 Construire rien pour l'utilisateur, sans que l'utilisateur soit impliqué
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 Concentrez-vous sur les besoins de vos utilisateurs, en utilisant des méthodes agiles, itératives et centrées sur l'utilisateur lors de la construction d'un service. Commencez par une recherche et une analyse approfondies pour vous aider à comprendre qui utilise le service, quels sont ses besoins et comment le service affectera sa vie pour mieux comprendre comment le service devrait être conçu. L'absence de la voix de l'utilisateur conduit à des hypothèses qui peuvent être incorrectes et coûteuses.
 
@@ -73,7 +50,7 @@ Les utilisateurs doivent être impliqués tout au long du cycle de vie du servic
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -99,7 +76,7 @@ Les utilisateurs doivent être impliqués tout au long du cycle de vie du servic
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'application
 
@@ -107,7 +84,7 @@ Les utilisateurs doivent être impliqués tout au long du cycle de vie du servic
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -116,23 +93,23 @@ Les utilisateurs doivent être impliqués tout au long du cycle de vie du servic
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est important de planifier la recherche continue des utilisateurs et les tests d'utilisabilité. Impliquer les utilisateurs à toutes les étapes, en recherchant continuellement des commentaires pour s'assurer que le service aide les utilisateurs à accomplir leurs tâches et continuer à améliorer le service pour mieux répondre aux besoins des utilisateurs.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -146,7 +123,7 @@ Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est import
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Stages bêta et en direct
 
@@ -169,7 +146,7 @@ Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est import
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'application
 
@@ -177,7 +154,7 @@ Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est import
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -186,7 +163,7 @@ Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est import
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.3 Comprendre le contexte dans lequel les gens interagissent et conçoivent des solutions adaptées à leurs besoins
 
@@ -194,7 +171,7 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -203,7 +180,7 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 - Clearly defined user needs **(Build It Right - OneGC Architectural Checklist (draft))**
   - User research, requirements and usability testing must be incorporated and tracked from the very beginning of any digital project
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -231,7 +208,7 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -265,7 +242,7 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -282,7 +259,7 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'application
 
@@ -326,7 +303,7 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -343,11 +320,11 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.4 Clairement articuler and understand the problem of about and use the data for evidence
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -355,7 +332,7 @@ We need to understand the different ways people will interact with our services,
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -371,7 +348,7 @@ We need to understand the different ways people will interact with our services,
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'application
 
@@ -379,7 +356,7 @@ We need to understand the different ways people will interact with our services,
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -388,17 +365,17 @@ We need to understand the different ways people will interact with our services,
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline dpgn-phase-alpha">
+<section class="dpgn-section-guideline dpgn-phase-alpha">
 
 ## 1.5 Fournir des services qui peuvent être tout, quand et n'importe quel appareil
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -411,7 +388,7 @@ We need to understand the different ways people will interact with our services,
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'application
 
@@ -419,7 +396,7 @@ We need to understand the different ways people will interact with our services,
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -428,11 +405,11 @@ We need to understand the different ways people will interact with our services,
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.6 Rendre les services simples, intuitifs et cohérents
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -454,7 +431,7 @@ Writing and designing content so it is consistent, plain and in the language of 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -504,7 +481,7 @@ Writing and designing content so it is consistent, plain and in the language of 
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'application
 
@@ -528,7 +505,7 @@ Writing and designing content so it is consistent, plain and in the language of 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -547,11 +524,11 @@ Writing and designing content so it is consistent, plain and in the language of 
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.7 Rendre plus pratique et pratique l'utilisation des services numériques
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -585,13 +562,13 @@ We still need to help users who are unable to use digital channels and provide s
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -627,7 +604,7 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -649,7 +626,7 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -671,7 +648,7 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Stages bêta et en direct
 
@@ -684,7 +661,7 @@ We still need to help users who are unable to use digital channels and provide s
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -698,7 +675,7 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -712,11 +689,11 @@ We still need to help users who are unable to use digital channels and provide s
 
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 1.8 Soutenir les personnes qui ne peuvent pas utiliser les services numériques par leurs propres moyens
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -730,7 +707,7 @@ You need to have a plan for what to do if your service goes offline so that you 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -756,7 +733,7 @@ You need to have a plan for what to do if your service goes offline so that you 
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -768,7 +745,7 @@ You need to have a plan for what to do if your service goes offline so that you 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 

--- a/fr/10-soyez-bons-gestionnaires-donnees.md
+++ b/fr/10-soyez-bons-gestionnaires-donnees.md
@@ -5,65 +5,48 @@ lang: fr
 altLang: en
 altLangPage: 10-be-good-data-stewards
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[10.1 Collecter les données une fois pour éviter la duplication](#user-content-101-collecter-les-données-une-fois-pour-éviter-la-duplication)
-
-[10.2 Rendre les informations et les données gouvernementales pertinentes facilement accessibles pour aider à la prise de décision](#user-content-102-rendre-les-informations-et-les-données-gouvernementales-pertinentes-facilement-accessibles-pour-aider-à-la-prise-de-décision)
-
-[10.3 Assurez-vous que les données sont collectées de manière standard afin qu'elles puissent être facilement intégrées et réutilisées par d'autres](#user-content-103-assurez-vous-que-les-données-sont-collectées-de-manière-standard-afin-quelles-puissent-être-facilement-intégrées-et-réutilisées-par-dautres)
-
-[10.4 Tenir dûment compte de la conservation et de la conservation numériques](#user-content-104-tenir-dûment-compte-de-la-conservation-et-de-la-conservation-numériques)
-
-[10.5 Assurer les données et dans la formation est complète, précise et à jour](#user-content-105-assurer-les-données-et-dans-la-formation-est-complète-précise-et-à-jour)
-
-[10.6 Assurez-vous que les données sont bien structurées, intuitives et dans un format facile à intégrer et réutiliser par d'autres](#user-content-106-assurez-vous-que-les-données-sont-bien-structurées-intuitives-et-dans-un-format-facile-à-intégrer-et-réutiliser-par-dautres)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
-[1.4 Clairement articuler and understand the problem of about and use the data for evidence (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-14-clairement-articuler-and-understand-the-problem-of-about-and-use-the-data-for-evidence)
-
-[5.1 Rendre toutes les données et informations non sensibles ouvertes au monde extérieur pour les partager et les réutiliser sous une licence ouverte (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-51-rendre-toutes-les-donn%C3%A9es-et-informations-non-sensibles-ouvertes-au-monde-ext%C3%A9rieur-pour-les-partager-et-les-r%C3%A9utiliser-sous-une-licence-ouverte)
-
-[5.2 Soyez transparent avec les objectifs et publiez les données de performance en temps réel (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-52-soyez-transparent-avec-les-objectifs-et-publiez-les-donn%C3%A9es-de-performance-en-temps-r%C3%A9el)
-
-[5.3 Mesurez et surveillez l'efficacité, la valeur et les conséquences de votre service et signalez publiquement (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-53-mesurez-et-surveillez-lefficacit%C3%A9-la-valeur-et-les-cons%C3%A9quences-de-votre-service-et-signalez-publiquement)
-
-[5.4 Soyez transparent sur la façon dont vous travaillez et justifiez les décisions que vous prenez (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-54-soyez-transparent-sur-la-fa%C3%A7on-dont-vous-travaillez-et-justifiez-les-d%C3%A9cisions-que-vous-prenez)
-
-[6.1 Tirer parti des normes ouvertes et adopter des pratiques exemplaires (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-61-tirer-parti-des-normes-ouvertes-et-adopter-des-pratiques-exemplaires)
-
-[6.2 Utiliser et réutiliser des solutions, des approches et des plateformes gouvernementales communes et éprouvées (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-62-utiliser-et-r%C3%A9utiliser-des-solutions-des-approches-et-des-plates-formes-gouvernementales-courantes-et-%C3%A9prouv%C3%A9es)
-
-[6.4 Ouvrez les données, les transactions et les règles métier qui sous-tendent un service (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-64-ouvrez-les-donn%C3%A9es-les-transactions-et-les-r%C3%A8gles-m%C3%A9tier-qui-sous-tendent-un-service)
-
-[9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-92-innover-et-sam%C3%A9liorer-tout-en-r%C3%A9pondant-aux-attentes-du-public-quant-%C3%A0-la-protection-de-la-confidentialit%C3%A9-des-donn%C3%A9es)
+- [1.4 Clairement articuler and understand the problem of about and use the data for evidence (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-14-clairement-articuler-and-understand-the-problem-of-about-and-use-the-data-for-evidence)
+- [5.1 Rendre toutes les données et informations non sensibles ouvertes au monde extérieur pour les partager et les réutiliser sous une licence ouverte (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-51-rendre-toutes-les-donn%C3%A9es-et-informations-non-sensibles-ouvertes-au-monde-ext%C3%A9rieur-pour-les-partager-et-les-r%C3%A9utiliser-sous-une-licence-ouverte)
+- [5.2 Soyez transparent avec les objectifs et publiez les données de performance en temps réel (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-52-soyez-transparent-avec-les-objectifs-et-publiez-les-donn%C3%A9es-de-performance-en-temps-r%C3%A9el)
+- [5.3 Mesurez et surveillez l'efficacité, la valeur et les conséquences de votre service et signalez publiquement (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-53-mesurez-et-surveillez-lefficacit%C3%A9-la-valeur-et-les-cons%C3%A9quences-de-votre-service-et-signalez-publiquement)
+- [5.4 Soyez transparent sur la façon dont vous travaillez et justifiez les décisions que vous prenez (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-54-soyez-transparent-sur-la-fa%C3%A7on-dont-vous-travaillez-et-justifiez-les-d%C3%A9cisions-que-vous-prenez)
+- [6.1 Tirer parti des normes ouvertes et adopter des pratiques exemplaires (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-61-tirer-parti-des-normes-ouvertes-et-adopter-des-pratiques-exemplaires)
+- [6.2 Utiliser et réutiliser des solutions, des approches et des plateformes gouvernementales communes et éprouvées (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-62-utiliser-et-r%C3%A9utiliser-des-solutions-des-approches-et-des-plates-formes-gouvernementales-courantes-et-%C3%A9prouv%C3%A9es)
+- [6.4 Ouvrez les données, les transactions et les règles métier qui sous-tendent un service (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-64-ouvrez-les-donn%C3%A9es-les-transactions-et-les-r%C3%A8gles-m%C3%A9tier-qui-sous-tendent-un-service)
+- [9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-92-innover-et-sam%C3%A9liorer-tout-en-r%C3%A9pondant-aux-attentes-du-public-quant-%C3%A0-la-protection-de-la-confidentialit%C3%A9-des-donn%C3%A9es)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.1 Collecter les données une fois pour éviter la duplication
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -71,7 +54,7 @@ altLangPage: 10-be-good-data-stewards
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -80,11 +63,11 @@ altLangPage: 10-be-good-data-stewards
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.2 Rendre les informations et les données gouvernementales pertinentes facilement accessibles pour aider à la prise de décision
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -92,7 +75,7 @@ At every stage of a project, we should measure how well our service is working f
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -116,7 +99,7 @@ At every stage of a project, we should measure how well our service is working f
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -132,7 +115,7 @@ At every stage of a project, we should measure how well our service is working f
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -141,11 +124,11 @@ At every stage of a project, we should measure how well our service is working f
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.3 Assurez-vous que les données sont collectées de manière standard afin qu'elles puissent être facilement intégrées et réutilisées par d'autres
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -175,13 +158,13 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Stages alpha, bêta et en direct
 
@@ -215,7 +198,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -231,7 +214,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -249,7 +232,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -283,7 +266,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -311,7 +294,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -324,17 +307,17 @@ Every service must aim for continuous improvement. Metrics are an important star
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.4 Tenir dûment compte de la conservation et de la conservation numériques
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -342,7 +325,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -364,17 +347,17 @@ Every service must aim for continuous improvement. Metrics are an important star
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.5 Assurer les données et dans la formation est complète, précise et à jour
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -386,7 +369,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -395,17 +378,17 @@ Every service must aim for continuous improvement. Metrics are an important star
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 10.6 Assurez-vous que les données sont bien structurées, intuitives et dans un format facile à intégrer et réutiliser par d'autres
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -419,7 +402,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 

--- a/fr/10-soyez-bons-gestionnaires-donnees.md
+++ b/fr/10-soyez-bons-gestionnaires-donnees.md
@@ -15,8 +15,10 @@ altLangPage: 10-be-good-data-stewards
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/fr/2-construire-dans-accessibilite-des-debut.md
+++ b/fr/2-construire-dans-accessibilite-des-debut.md
@@ -5,51 +5,40 @@ lang: fr
 altLang: en
 altLangPage: 2-build-in-accessibility-from-start
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[2.1 Construire pour ceux qui ont les plus grands besoins et cela fonctionnera pour tout le monde](#user-content-21-construire-pour-ceux-qui-ont-les-plus-grands-besoins-et-cela-fonctionnera-pour-tout-le-monde)
-
-[2.2 Les services devraient respecter ou dépasser les normes d'accessibilité et ne devraient pas être pénibles à utiliser](#user-content-22-les-services-devraient-respecter-ou-dépasser-les-normes-daccessibilité-et-ne-devraient-pas-être-pénibles-à-utiliser)
-
-[2.3 Co-créer avec des personnes ayant des besoins distincts, en étant inclusif dès le début](#user-content-23-co-créer-avec-des-personnes-ayant-des-besoins-distincts-en-étant-inclusif-dès-le-début)
-
-[2.4 Prendre en compte les contraintes possibles d'un utilisateur lors de la conception de services](#user-content-24-prendre-en-compte-les-contraintes-possibles-dun-utilisateur-lors-de-la-conception-de-services)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
-[1.1 Construire rien pour l'utilisateur, sans que l'utilisateur soit impliqué (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-11-construire-rien-pour-lutilisateur-sans-que-lutilisateur-soit-impliqu%C3%A9)
-
-[1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-12-simpliquer-aupr%C3%A8s-des-personnes-qui-ont-le-service-et-le-faire-participer-%C3%A0-toutes-les-%C3%A9tapes-de-la-planification-%C3%A0-lam%C3%A9lioration-continuer)
-
-[1.3 Comprendre le contexte dans lequel les gens interagissent et conçoivent des solutions adaptées à leurs besoins (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-13-comprendre-le-contexte-dans-lequel-les-gens-interagissent-et-con%C3%A7oivent-des-solutions-adapt%C3%A9es-%C3%A0-leurs-besoins)
-
-[1.5 Fournir des services qui peuvent être convertis n'importe où, n'importe où et n'importe quel appareil (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-15-fournir-des-services-qui-peuvent-%C3%AAtre-tout-quand-et-nimporte-quel-appareil)
-
-[1.6 Rendre les services simples, intuitifs et cohérents (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-16-rendre-les-services-simples-intuitifs-et-coh%C3%A9rents)
-
-[1.8 Soutenir les personnes qui ne peuvent pas utiliser les services numériques par leurs propres moyens (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-18-soutenir-les-personnes-qui-ne-peuvent-pas-utiliser-les-services-num%C3%A9riques-par-leurs-propres-moyens)
-
-[8.4 Équilibrer les compromis entre innovation et inclusivité (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-84-%C3%89quilibrer-les-compromis-entre-innovation-et-inclusivit%C3%A9)
+- [1.1 Construire rien pour l'utilisateur, sans que l'utilisateur soit impliqué (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-11-construire-rien-pour-lutilisateur-sans-que-lutilisateur-soit-impliqu%C3%A9)
+- [1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-12-simpliquer-aupr%C3%A8s-des-personnes-qui-ont-le-service-et-le-faire-participer-%C3%A0-toutes-les-%C3%A9tapes-de-la-planification-%C3%A0-lam%C3%A9lioration-continuer)
+- [1.3 Comprendre le contexte dans lequel les gens interagissent et conçoivent des solutions adaptées à leurs besoins (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-13-comprendre-le-contexte-dans-lequel-les-gens-interagissent-et-con%C3%A7oivent-des-solutions-adapt%C3%A9es-%C3%A0-leurs-besoins)
+- [1.5 Fournir des services qui peuvent être convertis n'importe où, n'importe où et n'importe quel appareil (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-15-fournir-des-services-qui-peuvent-%C3%AAtre-tout-quand-et-nimporte-quel-appareil)
+- [1.6 Rendre les services simples, intuitifs et cohérents (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-16-rendre-les-services-simples-intuitifs-et-coh%C3%A9rents)
+- [1.8 Soutenir les personnes qui ne peuvent pas utiliser les services numériques par leurs propres moyens (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-18-soutenir-les-personnes-qui-ne-peuvent-pas-utiliser-les-services-num%C3%A9riques-par-leurs-propres-moyens)
+- [8.4 Équilibrer les compromis entre innovation et inclusivité (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-84-%C3%89quilibrer-les-compromis-entre-innovation-et-inclusivit%C3%A9)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 2.1 Construire pour ceux qui ont les plus grands besoins et cela fonctionnera pour tout le monde
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 Le gouvernement du Canada est déterminé à faire en sorte qu'un niveau
 élevé d'accessibilité soit uniformément appliqué à tous ses canaux de prestation de services. Les technologies et les normes évoluent constamment et l'accessibilité joue un rôle majeur pour rendre le gouvernement du Canada plus efficace et inclusif. Une plus cohérente, pratique, clair et facile utilisateur expérience lors de l'utilisation des services gouvernementaux en ligne construit la confiance.
@@ -58,7 +47,7 @@ Le développement de services numériques accessibles (indépendamment de la cap
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -80,7 +69,7 @@ Le développement de services numériques accessibles (indépendamment de la cap
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -108,11 +97,11 @@ Le développement de services numériques accessibles (indépendamment de la cap
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 2.2 Les services devraient respecter ou dépasser les normes d'accessibilité, et ne devraient pas être pénibles à utiliser
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -132,7 +121,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -162,7 +151,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 - make sure your staff will be equipped with knowledge of barriers to accessibility and will be trained to assist users with disabilities in completing tasks and accessing information **(Digital Service Standard (Ontario))**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -184,7 +173,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -220,7 +209,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -238,7 +227,7 @@ Your service must be accessible to users regardless of their digital confidence 
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -267,7 +256,7 @@ Your service must be accessible to users regardless of their digital confidence 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -278,7 +267,7 @@ Your service must be accessible to users regardless of their digital confidence 
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 2.3 Co-créer avec des personnes ayant des besoins distincts, en étant inclusif dès le début
 
@@ -300,7 +289,7 @@ This applies when designing and developing:
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -355,7 +344,7 @@ For browsers, media players, and other 'user agents', follow User Agent Accessib
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -385,11 +374,11 @@ For browsers, media players, and other 'user agents', follow User Agent Accessib
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 2.4 Prendre en compte les contraintes possibles d'un utilisateur lors de la conception de services
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -403,7 +392,7 @@ Until you consider the needs of the range of people that will be using your serv
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -502,7 +491,7 @@ Until you consider the needs of the range of people that will be using your serv
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 

--- a/fr/2-construire-dans-accessibilite-des-debut.md
+++ b/fr/2-construire-dans-accessibilite-des-debut.md
@@ -15,8 +15,10 @@ altLangPage: 2-build-in-accessibility-from-start
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/fr/3-collaborez-largement.md
+++ b/fr/3-collaborez-largement.md
@@ -5,45 +5,37 @@ lang: fr
 altLang: en
 altLangPage: 3-collaborate-widely
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[3.1 Habiliter des équipes multidisciplinaires avec des perspectives et des compétences diverses](#user-content-31-habiliter-des-équipes-multidisciplinaires-avec-des-perspectives-et-des-compétences-diverses)
-
-[3.2 Reconnaître qu'une organisation ne peut pas avoir toutes les meilleures idées, créer des partenariats et collaborer avec un large éventail de partenaires](#user-content-32-reconnaître-quune-organisation-ne-peut-pas-avoir-toutes-les-meilleures-idées-créer-des-partenariats-et-collaborer-avec-un-large-éventail-de-partenaires)
-
-[3.3 Renforcer la capacité à attirer dynamiquement de nouveaux partenaires pour la co-innovation](#user-content-33-renforcer-la-capacité-à-attirer-dynamiquement-de-nouveaux-partenaires-pour-la-co-innovation)
-
-[3.4 Partager et collaborer à l'extérieur, établir un lien avec le travail des autres et fournir des ressources que d'autres peuvent réutiliser](#user-content-34-partager-et-collaborer-à-lextérieur-établir-un-lien-avec-le-travail-des-autres-et-fournir-des-ressources-que-dautres-peuvent-réutiliser)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
-[1.1 Construire rien pour l'utilisateur, sans que l'utilisateur soit impliqué (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-11-construire-rien-pour-lutilisateur-sans-que-lutilisateur-soit-impliqu%C3%A9)
-
-[1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-12-simpliquer-aupr%C3%A8s-des-personnes-qui-ont-le-service-et-le-faire-participer-%C3%A0-toutes-les-%C3%A9tapes-de-la-planification-%C3%A0-lam%C3%A9lioration-continuer)
-
-[2.3 Co-créer avec des personnes ayant des besoins distincts, en étant inclusif dès le début (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-23-co-cr%C3%A9er-avec-des-personnes-ayant-des-besoins-distincts-en-%C3%A9tant-inclusif-d%C3%A8s-le-d%C3%A9but)
-
-[5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-55-travailler-%C3%A0-lair-libre-et-rendre-le-code-source-ouvert-et-r%C3%A9utilisable)
+- [1.1 Construire rien pour l'utilisateur, sans que l'utilisateur soit impliqué (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-11-construire-rien-pour-lutilisateur-sans-que-lutilisateur-soit-impliqu%C3%A9)
+- [1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-12-simpliquer-aupr%C3%A8s-des-personnes-qui-ont-le-service-et-le-faire-participer-%C3%A0-toutes-les-%C3%A9tapes-de-la-planification-%C3%A0-lam%C3%A9lioration-continuer)
+- [2.3 Co-créer avec des personnes ayant des besoins distincts, en étant inclusif dès le début (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-23-co-cr%C3%A9er-avec-des-personnes-ayant-des-besoins-distincts-en-%C3%A9tant-inclusif-d%C3%A8s-le-d%C3%A9but)
+- [5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-55-travailler-%C3%A0-lair-libre-et-rendre-le-code-source-ouvert-et-r%C3%A9utilisable)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 3.1 Habiliter des équipes multidisciplinaires avec des perspectives et des compétences diverses
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -73,7 +65,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -141,7 +133,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -159,7 +151,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -174,17 +166,17 @@ Good government services are built quickly and iteratively, based on user needs.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 3.2 Reconnaître qu'une organisation ne peut pas avoir toutes les meilleures idées, créer des partenariats et collaborer avec un large éventail de partenaires
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -210,7 +202,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -230,11 +222,11 @@ Good government services are built quickly and iteratively, based on user needs.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 3.3 Renforcer la capacité à attirer dynamiquement de nouveaux partenaires pour la co-innovation
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -242,7 +234,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -250,7 +242,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -259,11 +251,11 @@ Good government services are built quickly and iteratively, based on user needs.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 3.4 Partager et collaborer à l'extérieur, établir un lien avec le travail des autres et fournir des ressources que d'autres peuvent réutiliser
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -273,7 +265,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -289,7 +281,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 - Show your code in an open Internet source code repository and enable contributions and comments on the code
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -307,7 +299,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -315,7 +307,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -340,7 +332,7 @@ Good government services are built quickly and iteratively, based on user needs.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -362,7 +354,7 @@ Good government services are built quickly and iteratively, based on user needs.
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 

--- a/fr/3-collaborez-largement.md
+++ b/fr/3-collaborez-largement.md
@@ -15,8 +15,10 @@ altLangPage: 3-collaborate-widely
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/fr/4-habiliter-personnel-fournir-meilleurs-services.md
+++ b/fr/4-habiliter-personnel-fournir-meilleurs-services.md
@@ -15,8 +15,10 @@ altLangPage: 4-empower-staff-deliver-better-services
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/fr/4-habiliter-personnel-fournir-meilleurs-services.md
+++ b/fr/4-habiliter-personnel-fournir-meilleurs-services.md
@@ -5,67 +5,50 @@ lang: fr
 altLang: en
 altLangPage: 4-empower-staff-deliver-better-services
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[4.1 Offrir des possibilités de formation continue etd'apprentissage pour améliorer continuellement les compétences de l'équipe et du réseau élargi](#user-content-41-offrir-des-possibilités-de-formation-continue-et-dapprentissage-pour-améliorer-continuellement-les-compétences-de-léquipe-et-du-réseau-élargi)
-
-[4.2 Assurez-vous que le personnel a accès aux outils et aux technologies dont il a besoin pour innover](#user-content-42-assurez-vous-que-le-personnel-a-accès-aux-outils-et-aux-technologies-dont-il-a-besoin-pour-innover)
-
-[4.3 Assurez-vous que les bons systèmes et processus sont en place pour que l'équipe puisse créer](#user-content-43-assurez-vous-que-les-bons-systèmes-et-processus-sont-en-place-pour-que-léquipe-puisse-créer)
-
-[4.4 Permettre aux équipes de prendre des décisions tout au long de la conception, de la construction et du fonctionnement du service et leur permettre d'apprendre de leurs erreurs](#user-content-44-permettre-aux-équipes-de-prendre-des-décisions-tout-au-long-de-la-conception-de-la-construction-et-du-fonctionnement-du-service-et-leur-permettre-dapprendre-de-leurs-erreurs)
-
-[4.5 Rendre une personne responsable du service](#user-content-45-rendre-une-personne-responsable-du-service)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
-[3.1 Habiliter des équipes multidisciplinaires avec des perspectives et des compétences diverses (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-31-habiliter-des-%C3%A9quipes-multidisciplinaires-avec-des-perspectives-et-des-comp%C3%A9tences-diverses)
-
-[3.2 Reconnaître qu'une organisation ne peut pas avoir toutes les meilleures idées, créer des partenariats et collaborer avec un large éventail de partenaires (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-32-reconna%C3%AEtre-quune-organisation-ne-peut-pas-avoir-toutes-les-meilleures-id%C3%A9es-cr%C3%A9er-des-partenariats-et-collaborer-avec-un-large-%C3%A9ventail-de-partenaires)
-
-[3.3 Renforcer la capacité à attirer dynamiquement de nouveaux partenaires pour la co-innovation (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-33-renforcer-la-capacit%C3%A9-%C3%A0-attirer-dynamiquement-de-nouveaux-partenaires-pour-la-co-innovation)
-
-[5.4 Soyez transparent sur la façon dont vous travaillez et justifiez les décisions que vous prenez (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-54-soyez-transparent-sur-la-fa%C3%A7on-dont-vous-travaillez-et-justifiez-les-d%C3%A9cisions-que-vous-prenez)
-
-[5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-55-travailler-%C3%A0-lair-libre-et-rendre-le-code-source-ouvert-et-r%C3%A9utilisable)
-
-[6.1 Tirer parti des normes ouvertes et adopter des pratiques exemplaires (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts](6-utiliser-standards-solutions-ouverts.md#user-content-61-tirer-parti-des-normes-ouvertes-et-adopter-des-pratiques-exemplaires)
-
-[6.2 Utiliser et réutiliser des solutions, des approches et des plateformes gouvernementales communes et éprouvées (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts](6-utiliser-standards-solutions-ouverts.md#user-content-62-utiliser-et-r%C3%A9utiliser-des-solutions-des-approches-et-des-plates-formes-gouvernementales-courantes-et-%C3%A9prouv%C3%A9es)
-
-[7.1 Construire de manière agile et améliorer continuellement en réponse aux besoins des utilisateurs (Norme&#160;7&#160;: Itérer et améliorer fréquemment](7-iterer-ameliorer-frequemment.md#user-content-71-construire-de-mani%C3%A8re-agile-et-am%C3%A9liorer-continuellement-en-r%C3%A9ponse-aux-besoins-des-utilisateurs)
-
-[7.2 Accepter que le changement est inévitable et utiliser des stratégies et des outils adaptatifs pour de nouveaux développements (Norme&#160;7&#160;: Itérer et améliorer fréquemment](7-iterer-ameliorer-frequemment.md#user-content-72-accepter-que-le-changement-est-in%C3%A9vitable-et-utiliser-des-strat%C3%A9gies-et-des-outils-adaptatifs-pour-de-nouveaux-d%C3%A9veloppements)
-
-[7.3 Embrasser et réagir aux changements dans l'environnement et concevoir pour la durabilité (Norme&#160;7&#160;: Itérer et améliorer fréquemment](7-iterer-ameliorer-frequemment.md#user-content-73-embrasser-et-r%C3%A9agir-aux-changements-dans-lenvironnement-et-concevoir-pour-la-durabilit%C3%A9)
-
-[7.4 Commencer petit et tester continuellement les conceptions et les hypothèses, en utilisant les preuves comme base de l'itération (Norme&#160;7&#160;: Itérer et améliorer fréquemment](7-iterer-ameliorer-frequemment.md#user-content-74-commencer-petit-et-tester-continuellement-les-conceptions-et-les-hypoth%C3%A8ses-en-utilisant-les-preuves-comme-base-de-lit%C3%A9ration)
+- [3.1 Habiliter des équipes multidisciplinaires avec des perspectives et des compétences diverses (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-31-habiliter-des-%C3%A9quipes-multidisciplinaires-avec-des-perspectives-et-des-comp%C3%A9tences-diverses)
+- [3.2 Reconnaître qu'une organisation ne peut pas avoir toutes les meilleures idées, créer des partenariats et collaborer avec un large éventail de partenaires (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-32-reconna%C3%AEtre-quune-organisation-ne-peut-pas-avoir-toutes-les-meilleures-id%C3%A9es-cr%C3%A9er-des-partenariats-et-collaborer-avec-un-large-%C3%A9ventail-de-partenaires)
+- [3.3 Renforcer la capacité à attirer dynamiquement de nouveaux partenaires pour la co-innovation (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-33-renforcer-la-capacit%C3%A9-%C3%A0-attirer-dynamiquement-de-nouveaux-partenaires-pour-la-co-innovation)
+- [5.4 Soyez transparent sur la façon dont vous travaillez et justifiez les décisions que vous prenez (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-54-soyez-transparent-sur-la-fa%C3%A7on-dont-vous-travaillez-et-justifiez-les-d%C3%A9cisions-que-vous-prenez)
+- [5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-55-travailler-%C3%A0-lair-libre-et-rendre-le-code-source-ouvert-et-r%C3%A9utilisable)
+- [6.1 Tirer parti des normes ouvertes et adopter des pratiques exemplaires (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts](6-utiliser-standards-solutions-ouverts.md#user-content-61-tirer-parti-des-normes-ouvertes-et-adopter-des-pratiques-exemplaires)
+- [6.2 Utiliser et réutiliser des solutions, des approches et des plateformes gouvernementales communes et éprouvées (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts](6-utiliser-standards-solutions-ouverts.md#user-content-62-utiliser-et-r%C3%A9utiliser-des-solutions-des-approches-et-des-plates-formes-gouvernementales-courantes-et-%C3%A9prouv%C3%A9es)
+- [7.1 Construire de manière agile et améliorer continuellement en réponse aux besoins des utilisateurs (Norme&#160;7&#160;: Itérer et améliorer fréquemment](7-iterer-ameliorer-frequemment.md#user-content-71-construire-de-mani%C3%A8re-agile-et-am%C3%A9liorer-continuellement-en-r%C3%A9ponse-aux-besoins-des-utilisateurs)
+- [7.2 Accepter que le changement est inévitable et utiliser des stratégies et des outils adaptatifs pour de nouveaux développements (Norme&#160;7&#160;: Itérer et améliorer fréquemment](7-iterer-ameliorer-frequemment.md#user-content-72-accepter-que-le-changement-est-in%C3%A9vitable-et-utiliser-des-strat%C3%A9gies-et-des-outils-adaptatifs-pour-de-nouveaux-d%C3%A9veloppements)
+- [7.3 Embrasser et réagir aux changements dans l'environnement et concevoir pour la durabilité (Norme&#160;7&#160;: Itérer et améliorer fréquemment](7-iterer-ameliorer-frequemment.md#user-content-73-embrasser-et-r%C3%A9agir-aux-changements-dans-lenvironnement-et-concevoir-pour-la-durabilit%C3%A9)
+- [7.4 Commencer petit et tester continuellement les conceptions et les hypothèses, en utilisant les preuves comme base de l'itération (Norme&#160;7&#160;: Itérer et améliorer fréquemment](7-iterer-ameliorer-frequemment.md#user-content-74-commencer-petit-et-tester-continuellement-les-conceptions-et-les-hypoth%C3%A8ses-en-utilisant-les-preuves-comme-base-de-lit%C3%A9ration)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.1 Offrir des possibilités de formation continue et d'apprentissage pour améliorer continuellement les compétences de l'équipe et du réseau élargi
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -73,7 +56,7 @@ altLangPage: 4-empower-staff-deliver-better-services
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -82,11 +65,11 @@ altLangPage: 4-empower-staff-deliver-better-services
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.2 Assurez-vous que le personnel a accès aux outils et aux technologies dont il a besoin pour innover
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -117,7 +100,7 @@ The technology you choose to build your service must help you respond quickly an
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -125,7 +108,7 @@ The technology you choose to build your service must help you respond quickly an
 
 - Ensure the project team has a modern workplace, professional development and the IM-IT tools they need to do their jobs
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -157,7 +140,7 @@ The technology you choose to build your service must help you respond quickly an
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -185,7 +168,7 @@ The technology you choose to build your service must help you respond quickly an
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -210,7 +193,7 @@ The technology you choose to build your service must help you respond quickly an
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -220,7 +203,7 @@ The technology you choose to build your service must help you respond quickly an
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -231,7 +214,7 @@ The technology you choose to build your service must help you respond quickly an
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.3 Assurez-vous que les bons systèmes et processus sont en place pour que l'équipe puisse créer
 
@@ -243,7 +226,7 @@ It is essential that business processes be reviewed to identify opportunities to
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -283,7 +266,7 @@ It is essential that business processes be reviewed to identify opportunities to
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -291,7 +274,7 @@ It is essential that business processes be reviewed to identify opportunities to
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -302,17 +285,17 @@ It is essential that business processes be reviewed to identify opportunities to
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.4 Permettre aux équipes de prendre des décisions tout au long de la conception, de la construction et du fonctionnement du service et leur permettre d'apprendre de leurs erreurs
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -336,7 +319,7 @@ It is essential that business processes be reviewed to identify opportunities to
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -347,11 +330,11 @@ It is essential that business processes be reviewed to identify opportunities to
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 4.5 Rendre une personne responsable du service
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -359,7 +342,7 @@ Each service must have one person who has the authority and is responsibile for 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -387,7 +370,7 @@ Each service must have one person who has the authority and is responsibile for 
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -395,7 +378,7 @@ Each service must have one person who has the authority and is responsibile for 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 

--- a/fr/5-travailler-air-libre-par-defaut.md
+++ b/fr/5-travailler-air-libre-par-defaut.md
@@ -5,55 +5,44 @@ lang: fr
 altLang: en
 altLangPage: 5-work-in-open-by-default
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[5.1 Rendre toutes les données et informations non sensibles ouvertes au monde extérieur pour les partager et les réutiliser sous une licence ouverte](#user-content-51-rendre-toutes-les-données-et-informations-non-sensibles-ouvertes-au-monde-extérieur-pour-les-partager-et-les-réutiliser-sous-une-licence-ouverte)
-
-[5.2 Soyez transparent avec les objectifs et publiez les données de performance en temps réel](#user-content-52-soyez-transparent-avec-les-objectifs-et-publiez-les-données-de-performance-en-temps-réel)
-
-[5.3 Mesurez et surveillez l'efficacité, la valeur et les conséquences de votre service et signalez publiquement](#user-content-53-mesurez-et-surveillez-lefficacité-la-valeur-et-les-conséquences-de-votre-service-et-signalez-publiquement)
-
-[5.4 Soyez transparent sur la façon dont vous travaillez et justifiez les décisions que vous prenez](#user-content-54-soyez-transparent-sur-la-façon-dont-vous-travaillez-et-justifiez-les-décisions-que-vous-prenez)
-
-[5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable](#user-content-55-travailler-à-lair-libre-et-rendre-le-code-source-ouvert-et-réutilisable)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
-[3.4 Partager et collaborer à l'extérieur, établir un lien avec le travail des autres et fournir des ressources que d'autres peuvent réutiliser (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-34-partager-et-collaborer-%C3%A0-lext%C3%A9rieur-%C3%A9tablir-un-lien-avec-le-travail-des-autres-et-fournir-des-ressources-que-dautres-peuvent-r%C3%A9utiliser)
-
-[6.3 Conception pour l'interopérabilité, permettant aux services d'être découverts et exploités par la communauté (Norme&#160;6&#160;: Utiliser des normes et des solutions ouvertes)](6-utiliser-standards-solutions-ouverts.md#user-content-63-conception-pour-linterop%C3%A9rabilit%C3%A9-permettant-aux-services-d%C3%AAtre-d%C3%A9couverts-et-exploit%C3%A9s-par-la-communaut%C3%A9)
-
-[6.4 Ouvrir les données, les transactions et les règles métier qui sous-tendent un service (Norme&#160;6&#160;: Utiliser des normes et des solutions ouvertes)](6-utiliser-standards-solutions-ouverts.md#user-content-64-ouvrez-les-données-les-transactions-et-les-règles-métier-qui-sous-tendent-un-service)
-
-[8.1 Soyez transparent au sujet des préjugés personnels et organisationnels et indiquez comment ils sont traités (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-81-soyez-transparent-au-sujet-des-pr%C3%A9jug%C3%A9s-personnels-et-organisationnels-et-indiquez-comment-ils-sont-trait%C3%A9s)
-
-[10.2 Rendre les informations et les données gouvernementales pertinentes facilement accessibles pour aider à la prise de décision (Norme&#160;10&#160;: Soyez de bons gestionnaires de données)](10-soyez-bons-gestionnaires-donnees.md#user-content-102-rendre-les-informations-et-les-donn%C3%A9es-gouvernementales-pertinentes-facilement-accessibles-pour-aider-%C3%A0-la-prise-de-d%C3%A9cision)
+- [3.4 Partager et collaborer à l'extérieur, établir un lien avec le travail des autres et fournir des ressources que d'autres peuvent réutiliser (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-34-partager-et-collaborer-%C3%A0-lext%C3%A9rieur-%C3%A9tablir-un-lien-avec-le-travail-des-autres-et-fournir-des-ressources-que-dautres-peuvent-r%C3%A9utiliser)
+- [6.3 Conception pour l'interopérabilité, permettant aux services d'être découverts et exploités par la communauté (Norme&#160;6&#160;: Utiliser des normes et des solutions ouvertes)](6-utiliser-standards-solutions-ouverts.md#user-content-63-conception-pour-linterop%C3%A9rabilit%C3%A9-permettant-aux-services-d%C3%AAtre-d%C3%A9couverts-et-exploit%C3%A9s-par-la-communaut%C3%A9)
+- [6.4 Ouvrir les données, les transactions et les règles métier qui sous-tendent un service (Norme&#160;6&#160;: Utiliser des normes et des solutions ouvertes)](6-utiliser-standards-solutions-ouverts.md#user-content-64-ouvrez-les-données-les-transactions-et-les-règles-métier-qui-sous-tendent-un-service)
+- [8.1 Soyez transparent au sujet des préjugés personnels et organisationnels et indiquez comment ils sont traités (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-81-soyez-transparent-au-sujet-des-pr%C3%A9jug%C3%A9s-personnels-et-organisationnels-et-indiquez-comment-ils-sont-trait%C3%A9s)
+- [10.2 Rendre les informations et les données gouvernementales pertinentes facilement accessibles pour aider à la prise de décision (Norme&#160;10&#160;: Soyez de bons gestionnaires de données)](10-soyez-bons-gestionnaires-donnees.md#user-content-102-rendre-les-informations-et-les-donn%C3%A9es-gouvernementales-pertinentes-facilement-accessibles-pour-aider-%C3%A0-la-prise-de-d%C3%A9cision)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.1 Rendre toutes les données et informations non sensibles ouvertes au monde extérieur pour les partager et les réutiliser sous une licence ouverte
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -73,7 +62,7 @@ altLangPage: 5-work-in-open-by-default
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -86,17 +75,17 @@ altLangPage: 5-work-in-open-by-default
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.2 Soyez transparent avec les objectifs et publiez les données de performance en temps réel
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -104,7 +93,7 @@ altLangPage: 5-work-in-open-by-default
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -113,11 +102,11 @@ altLangPage: 5-work-in-open-by-default
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.3 Mesurez et surveillez l'efficacité, la valeur et les conséquences de votre service et signalez publiquement
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -133,13 +122,13 @@ Setting performance indicators allows you to continuously improve your service b
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Stages alpha, bêta et en direct
 
@@ -165,7 +154,7 @@ Setting performance indicators allows you to continuously improve your service b
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -174,7 +163,7 @@ Setting performance indicators allows you to continuously improve your service b
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -194,7 +183,7 @@ Setting performance indicators allows you to continuously improve your service b
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -203,11 +192,11 @@ Setting performance indicators allows you to continuously improve your service b
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.4 Soyez transparent sur la façon dont vous travaillez et justifiez les décisions que vous prenez
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -215,7 +204,7 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -239,7 +228,7 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -247,7 +236,7 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -258,11 +247,11 @@ Share your experiences with colleagues across the Government of Canada, other le
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -290,7 +279,7 @@ Open source helps to:
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -310,7 +299,7 @@ Open source helps to:
   - Actively use and contribute to open source tools and solutions
   - Develop in the open by sharing and reusing all types of code and platform configuration
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -328,7 +317,7 @@ Open source helps to:
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -336,7 +325,7 @@ Open source helps to:
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -361,7 +350,7 @@ Open source helps to:
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -383,7 +372,7 @@ Open source helps to:
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 

--- a/fr/5-travailler-air-libre-par-defaut.md
+++ b/fr/5-travailler-air-libre-par-defaut.md
@@ -15,8 +15,10 @@ altLangPage: 5-work-in-open-by-default
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/fr/6-utiliser-standards-solutions-ouverts.md
+++ b/fr/6-utiliser-standards-solutions-ouverts.md
@@ -15,8 +15,10 @@ altLangPage: 6-use-open-standards-solutions
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/fr/6-utiliser-standards-solutions-ouverts.md
+++ b/fr/6-utiliser-standards-solutions-ouverts.md
@@ -5,51 +5,38 @@ lang: fr
 altLang: en
 altLangPage: 6-use-open-standards-solutions
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[6.1 Tirer parti des normes ouvertes et adopter des pratiques exemplaires](#user-content-61-tirer-parti-des-normes-ouvertes-et-adopter-des-pratiques-exemplaires)
-
-[6.2 Utiliser et réutiliser des solutions, des approches et des plateformes gouvernementales communes et éprouvées](#user-content-62-utiliser-et-réutiliser-des-solutions-des-approches-et-des-plates-formes-gouvernementales-courantes-et-éprouvées)
-
-[6.3 Conception pour l'interopérabilité, permettant aux services d'être découverts et exploités par la communauté](#user-content-63-conception-pour-linteropérabilité-permettant-aux-services-dêtre-découverts-et-exploités-par-la-communauté)
-
-[6.4 Ouvrez les données, les transactions et les règles métier qui sous-tendent un service](#user-content-64-ouvrez-les-données-les-transactions-et-les-règles-métier-qui-sous-tendent-un-service)
-
-[6.5 Concevoir, créer et tester des services numériques de bout en bout](#user-content-65-concevoir-créer-et-tester-des-services-numériques-de-bout-en-bout)
-
-[6.6 Nuage d'abord](#user-content-66-nuage-dabord)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes:**
 
-[1.5 Fournir des services qui peuvent être convertis n'importe où, n'importe où et n'importe quel appareil (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-15-fournir-des-services-qui-peuvent-être-tout-quand-et-nimporte-quel-appareil)
-
-[3.4 Partager et collaborer à l'extérieur, établir un lien avec le travail des autres et fournir des ressources que d'autres peuvent réutiliser (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-34-partager-et-collaborer-à-lextérieur-établir-un-lien-avec-le-travail-des-autres-et-fournir-des-ressources-que-dautres-peuvent-réutiliser)
-
-[5.1 Rendre toutes les données et informations non sensibles ouvertes au monde extérieur pour les partager et les réutiliser sous licence ouverte (Norme&#160;5&#160;: Travailler à l'extérieur par défaut)](5-travailler-air-libre-par-defaut.md#user-content-51-rendre-toutes-les-données-et-informations-non-sensibles-ouvertes-au-monde-extérieur-pour-les-partager-et-les-réutiliser-sous-une-licence-ouverte)
-
-[5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-55-travailler-à-lair-libre-et-rendre-le-code-source-ouvert-et-réutilisable)
-
-[10.3 Assurez-vous que les données sont collectées de manière standard afin qu'elles puissent être facilement intégrées et réutilisées par d'autres (Norme&#160;10&#160;: Soyez de bons gestionnaires de données)](10-soyez-bons-gestionnaires-donnees.md#user-content-103-assurez-vous-que-les-données-sont-collectées-de-manière-standard-afin-quelles-puissent-être-facilement-intégrées-et-réutilisées-par-dautres)
+- [1.5 Fournir des services qui peuvent être convertis n'importe où, n'importe où et n'importe quel appareil (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-15-fournir-des-services-qui-peuvent-être-tout-quand-et-nimporte-quel-appareil)
+- [3.4 Partager et collaborer à l'extérieur, établir un lien avec le travail des autres et fournir des ressources que d'autres peuvent réutiliser (Norme&#160;3&#160;: Collaborez largement)](3-collaborez-largement.md#user-content-34-partager-et-collaborer-à-lextérieur-établir-un-lien-avec-le-travail-des-autres-et-fournir-des-ressources-que-dautres-peuvent-réutiliser)
+- [5.1 Rendre toutes les données et informations non sensibles ouvertes au monde extérieur pour les partager et les réutiliser sous licence ouverte (Norme&#160;5&#160;: Travailler à l'extérieur par défaut)](5-travailler-air-libre-par-defaut.md#user-content-51-rendre-toutes-les-données-et-informations-non-sensibles-ouvertes-au-monde-extérieur-pour-les-partager-et-les-réutiliser-sous-une-licence-ouverte)
+- [5.5 Travailler à l'air libre et rendre le code source ouvert et réutilisable (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-55-travailler-à-lair-libre-et-rendre-le-code-source-ouvert-et-réutilisable)
+- [10.3 Assurez-vous que les données sont collectées de manière standard afin qu'elles puissent être facilement intégrées et réutilisées par d'autres (Norme&#160;10&#160;: Soyez de bons gestionnaires de données)](10-soyez-bons-gestionnaires-donnees.md#user-content-103-assurez-vous-que-les-données-sont-collectées-de-manière-standard-afin-quelles-puissent-être-facilement-intégrées-et-réutilisées-par-dautres)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.1 Tirer parti des normes ouvertes et adopter des pratiques exemplaires
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -87,7 +74,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -100,7 +87,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 - Use emerging technologies **(Build It Right - OneGC Architectural Checklist (draft))**
   - Leverage new technologies (e.g., AI and blockchain) to shift investments to more modern tec
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -114,7 +101,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Stages bêta et en direct
 
@@ -127,7 +114,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -147,7 +134,7 @@ move between different technologies when you need to, avoiding vendor lock-in.
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -162,11 +149,11 @@ move between different technologies when you need to, avoiding vendor lock-in.
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.2 Utiliser et réutiliser des solutions, des approches et des plates-formes gouvernementales courantes et éprouvées
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -176,7 +163,7 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -231,7 +218,7 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -239,7 +226,7 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -254,11 +241,11 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.3 Conception pour l'interopérabilité, permettant aux services d'être découverts et exploités par la communauté
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -266,7 +253,7 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -290,7 +277,7 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -305,17 +292,17 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.4 Ouvrez les données, les transactions et les règles métier qui sous-tendent un service
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -323,7 +310,7 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -340,11 +327,11 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.5 Concevoir, créer et tester des services numériques de bout en bout
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -352,7 +339,7 @@ There are many potential benefits from the greater use of digital services, incl
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -388,7 +375,7 @@ There are many potential benefits from the greater use of digital services, incl
 
 - Conduct load and performance tests at regular intervals, including before public launch **(Digital Services Playbook (US))**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -396,7 +383,7 @@ There are many potential benefits from the greater use of digital services, incl
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Stage bêta et en direct
 
@@ -421,7 +408,7 @@ There are many potential benefits from the greater use of digital services, incl
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -447,7 +434,7 @@ There are many potential benefits from the greater use of digital services, incl
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -464,7 +451,7 @@ There are many potential benefits from the greater use of digital services, incl
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 6.6 Nuage d'abord
 
@@ -489,7 +476,7 @@ Public cloud services offer benefits that enable significant advances in the fol
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -511,7 +498,7 @@ Public cloud services offer benefits that enable significant advances in the fol
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -519,7 +506,7 @@ Public cloud services offer benefits that enable significant advances in the fol
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 

--- a/fr/7-iterer-ameliorer-frequemment.md
+++ b/fr/7-iterer-ameliorer-frequemment.md
@@ -5,43 +5,36 @@ lang: fr
 altLang: en
 altLangPage: 7-iterate-improve-frequently
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[7.1 Construire de manière agile et améliorer continuellement en réponse aux besoins des utilisateurs](#user-content-71-construire-de-manière-agile-et-améliorer-continuellement-en-réponse-aux-besoins-des-utilisateurs)
-
-[7.2 Accepter que le changement est inévitable et utiliser des stratégies et des outils adaptatifs pour de nouveaux développements](#user-content-72-accepter-que-le-changement-est-inévitable-et-utiliser-des-stratégies-et-des-outils-adaptatifs-pour-de-nouveaux-développements)
-
-[7.3 Embrasser et réagir aux changements dans l'environnement et concevoir pour la durabilité](#user-content-73-embrasser-et-réagir-aux-changements-dans-lenvironnement-et-concevoir-pour-la-durabilité)
-
-[7.4 Commencer petit et tester continuellement les conceptions et les hypothèses, en utilisant les preuves comme base de l'itération](#user-content-74-commencer-petit-et-tester-continuellement-les-conceptions-et-les-hypothèses-en-utilisant-les-preuves-comme-base-de-litération)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexesv:**
 
-[1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-12-simpliquer-aupr%C3%A8s-des-personnes-qui-ont-le-service-et-le-faire-participer-%C3%A0-toutes-les-%C3%A9tapes-de-la-planification-%C3%A0-lam%C3%A9lioration-continuer)
-
-[3.3 Renforcer la capacité à attirer dynamiquement de nouveaux partenaires pour la co-innovation (Norme&#160;3&#160;: Collaborez)](3-collaborez-largement.md#user-content-33-renforcer-la-capacit%C3%A9-%C3%A0-attirer-dynamiquement-de-nouveaux-partenaires-pour-la-co-innovation)
-
-[9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-92-innover-et-sam%C3%A9liorer-tout-en-r%C3%A9pondant-aux-attentes-du-public-quant-%C3%A0-la-protection-de-la-confidentialit%C3%A9-des-donn%C3%A9es)
+- [1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-12-simpliquer-aupr%C3%A8s-des-personnes-qui-ont-le-service-et-le-faire-participer-%C3%A0-toutes-les-%C3%A9tapes-de-la-planification-%C3%A0-lam%C3%A9lioration-continuer)
+- [3.3 Renforcer la capacité à attirer dynamiquement de nouveaux partenaires pour la co-innovation (Norme&#160;3&#160;: Collaborez)](3-collaborez-largement.md#user-content-33-renforcer-la-capacit%C3%A9-%C3%A0-attirer-dynamiquement-de-nouveaux-partenaires-pour-la-co-innovation)
+- [9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-92-innover-et-sam%C3%A9liorer-tout-en-r%C3%A9pondant-aux-attentes-du-public-quant-%C3%A0-la-protection-de-la-confidentialit%C3%A9-des-donn%C3%A9es)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 7.1 Construire de manière agile et améliorer continuellement en réponse aux besoins des utilisateurs
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -99,7 +92,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -109,7 +102,7 @@ Start with a representation or prototype of the solution that will be tested and
   - Be an agile Developer: Develop in an iterative manner, with key stakeholders participation from the beginning, releasing minimum viable product as soon as possible and iteratively building out functionality
   - Be an agile administrator: Promote DEVOPS and automate, monitor and unify all platform and software construction from testing to release and infrastructure management
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -123,7 +116,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-beta dpgn-phase-live">
 
 #### Stages bêta et en direct
 
@@ -135,7 +128,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Stages alpha, bêta et en direct
 
@@ -222,7 +215,7 @@ Start with a representation or prototype of the solution that will be tested and
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -272,7 +265,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources connexes
 
@@ -289,17 +282,17 @@ Start with a representation or prototype of the solution that will be tested and
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 7.2 Accepter que le changement est inévitable et utiliser des stratégies et des outils adaptatifs pour de nouveaux développements
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -307,7 +300,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -316,11 +309,11 @@ Start with a representation or prototype of the solution that will be tested and
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 7.3 Embrasser et réagir aux changements dans l'environnement et concevoir pour la durabilité
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -328,7 +321,7 @@ Once you have designed and launched a service, there is still work to do. Treat 
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -342,7 +335,7 @@ Once you have designed and launched a service, there is still work to do. Treat 
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -350,7 +343,7 @@ Once you have designed and launched a service, there is still work to do. Treat 
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -359,11 +352,11 @@ Once you have designed and launched a service, there is still work to do. Treat 
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 7.4 Commencer petit et tester continuellement les conceptions et les hypothèses, en utilisant les preuves comme base de l'itération
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -381,7 +374,7 @@ You need to build a service which you can iterate and keep improving so that you
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -415,7 +408,7 @@ You need to build a service which you can iterate and keep improving so that you
     - Card Sorting Testing - A reverse tree test where participants sort through items and group them together in a hierarchal manner.
     - First Click Testing - A test that observes the first item that a participant clicks on and uses the selection as an indication as to whether users are directed as intended.
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-alpha dpgn-phase-beta dpgn-phase-live">
 
 #### Stages alpha, bêta et en direct
 
@@ -439,7 +432,7 @@ You need to build a service which you can iterate and keep improving so that you
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -449,7 +442,7 @@ You need to build a service which you can iterate and keep improving so that you
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -460,7 +453,7 @@ You need to build a service which you can iterate and keep improving so that you
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -490,7 +483,7 @@ Find out more about:
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 

--- a/fr/7-iterer-ameliorer-frequemment.md
+++ b/fr/7-iterer-ameliorer-frequemment.md
@@ -15,8 +15,10 @@ altLangPage: 7-iterate-improve-frequently
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/fr/8-concevoir-services-ethiques.md
+++ b/fr/8-concevoir-services-ethiques.md
@@ -5,71 +5,53 @@ lang: fr
 altLang: en
 altLangPage: 8-design-ethical-services
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[8.1 Soyez transparent au sujet des préjugés personnels et organisationnels et indiquez comment ils sont traités](#user-content-81-soyez-transparent-au-sujet-des-préjugés-personnels-et-organisationnels-et-indiquez-comment-ils-sont-traités)
-
-[8.2 Évaluer l'impact total sur les utilisateurs et les communautés](#user-content-82-Évaluer-limpact-total-sur-les-utilisateurs-et-les-communautés)
-
-[8.3 Se conformer aux directives éthiques dans la conception de systèmes automatisés](#user-content-83-se-conformer-aux-directives-éthiques-dans-la-conception-de-systèmes-automatisés)
-
-[8.4 Équilibrer les compromis entre innovation et inclusivité](#user-content-84-Équilibrer-les-compromis-entre-innovation-et-inclusivité)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrices connexes :**
 
-[1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-12-simpliquer-aupr%C3%A8s-des-personnes-qui-ont-le-service-et-le-faire-participer-%C3%A0-toutes-les-%C3%A9tapes-de-la-planification-%C3%A0-lam%C3%A9lioration-continuer)
-
-[1.3 Comprendre le contexte dans lequel les gens interagissent et conçoivent des solutions adaptées à leurs besoins (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-13-comprendre-le-contexte-dans-lequel-les-gens-interagissent-et-con%C3%A7oivent-des-solutions-adapt%C3%A9es-%C3%A0-leurs-besoins)
-
-[1.4 Clairement articuler and understand the problem of about and use the data for evidence (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-14-clairement-articuler-and-understand-the-problem-of-about-and-use-the-data-for-evidence)
-
-[1.8 Soutenir les personnes qui ne peuvent pas utiliser les services numériques par leurs propres moyens (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-18-soutenir-les-personnes-qui-ne-peuvent-pas-utiliser-les-services-num%C3%A9riques-par-leurs-propres-moyens)
-
-[2.1 Construire pour ceux qui ont les plus grands besoins et cela fonctionnera pour tout le monde (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-21-construire-pour-ceux-qui-ont-les-plus-grands-besoins-et-cela-fonctionnera-pour-tout-le-monde)
-
-[2.2 Les services devraient respecter ou dépasser les normes d'accessibilité et ne devraient pas être pénibles à utiliser (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-22-les-services-devraient-respecter-ou-d%C3%A9passer-les-normes-daccessibilit%C3%A9-et-ne-devraient-pas-%C3%AAtre-p%C3%A9nibles-%C3%A0-utiliser)
-
-[2.4 Prendre en compte les contraintes possibles d'un utilisateur lors de la conception de services (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-24-prendre-en-compte-les-contraintes-possibles-dun-utilisateur-lors-de-la-conception-de-services)
-
-[5.2 Soyez transparent avec les objectifs et publiez les données de performance en temps réel (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-52-soyez-transparent-avec-les-objectifs-et-publiez-les-donn%C3%A9es-de-performance-en-temps-r%C3%A9el)
-
-[5.3 Mesurez et surveillez l'efficacité, la valeur et les conséquences de votre service et signalez publiquement (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-53-mesurez-et-surveillez-lefficacit%C3%A9-la-valeur-et-les-cons%C3%A9quences-de-votre-service-et-signalez-publiquement)
-
-[5.4 Soyez transparent sur la façon dont vous travaillez et justifiez les décisions que vous prenez (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-54-soyez-transparent-sur-la-fa%C3%A7on-dont-vous-travaillez-et-justifiez-les-d%C3%A9cisions-que-vous-prenez)
-
-[9.1 Adopter une approche équilibrée de gestion des risques en mettant en œuvre des mesures de sécurité et de confidentialité appropriées (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-91-adopter-une-approche-%C3%A9quilibr%C3%A9e-de-gestion-des-risques-en-mettant-en-%C5%93uvre-des-mesures-de-s%C3%A9curit%C3%A9-et-de-confidentialit%C3%A9-appropri%C3%A9es)
-
-[9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-92-innover-et-sam%C3%A9liorer-tout-en-r%C3%A9pondant-aux-attentes-du-public-quant-%C3%A0-la-protection-de-la-confidentialit%C3%A9-des-donn%C3%A9es)
-
-[9.3 Faites en sorte que la sécurité soit fluide et sans friction, en équilibrant sécurité et commodité (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-93-faites-en-sorte-que-la-s%C3%A9curit%C3%A9-soit-fluide-et-sans-friction-en-%C3%A9quilibrant-s%C3%A9curit%C3%A9-et-commodit%C3%A9)
-
-[9.4 S'assurer que les services sont conformes à toutes les exigences législatives et réglementaires (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-94-sassurer-que-les-services-sont-conformes-%C3%A0-toutes-les-exigences-l%C3%A9gislatives-et-r%C3%A9glementaires)
+- [1.2 S'impliquer auprès des personnes qui ont le service et le faire participer à toutes les étapes, de la planification à l'amélioration continuer (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-12-simpliquer-aupr%C3%A8s-des-personnes-qui-ont-le-service-et-le-faire-participer-%C3%A0-toutes-les-%C3%A9tapes-de-la-planification-%C3%A0-lam%C3%A9lioration-continuer)
+- [1.3 Comprendre le contexte dans lequel les gens interagissent et conçoivent des solutions adaptées à leurs besoins (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-13-comprendre-le-contexte-dans-lequel-les-gens-interagissent-et-con%C3%A7oivent-des-solutions-adapt%C3%A9es-%C3%A0-leurs-besoins)
+- [1.4 Clairement articuler and understand the problem of about and use the data for evidence (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-14-clairement-articuler-and-understand-the-problem-of-about-and-use-the-data-for-evidence)
+- [1.8 Soutenir les personnes qui ne peuvent pas utiliser les services numériques par leurs propres moyens (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-18-soutenir-les-personnes-qui-ne-peuvent-pas-utiliser-les-services-num%C3%A9riques-par-leurs-propres-moyens)
+- [2.1 Construire pour ceux qui ont les plus grands besoins et cela fonctionnera pour tout le monde (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-21-construire-pour-ceux-qui-ont-les-plus-grands-besoins-et-cela-fonctionnera-pour-tout-le-monde)
+- [2.2 Les services devraient respecter ou dépasser les normes d'accessibilité et ne devraient pas être pénibles à utiliser (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-22-les-services-devraient-respecter-ou-d%C3%A9passer-les-normes-daccessibilit%C3%A9-et-ne-devraient-pas-%C3%AAtre-p%C3%A9nibles-%C3%A0-utiliser)
+- [2.4 Prendre en compte les contraintes possibles d'un utilisateur lors de la conception de services (Norme&#160;2&#160;: Construire dans l'accessibilité dès le début)](2-construire-dans-accessibilite-des-debut.md#user-content-24-prendre-en-compte-les-contraintes-possibles-dun-utilisateur-lors-de-la-conception-de-services)
+- [5.2 Soyez transparent avec les objectifs et publiez les données de performance en temps réel (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-52-soyez-transparent-avec-les-objectifs-et-publiez-les-donn%C3%A9es-de-performance-en-temps-r%C3%A9el)
+- [5.3 Mesurez et surveillez l'efficacité, la valeur et les conséquences de votre service et signalez publiquement (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-53-mesurez-et-surveillez-lefficacit%C3%A9-la-valeur-et-les-cons%C3%A9quences-de-votre-service-et-signalez-publiquement)
+- [5.4 Soyez transparent sur la façon dont vous travaillez et justifiez les décisions que vous prenez (Norme&#160;5&#160;: Travailler à l'air libre par défaut)](5-travailler-air-libre-par-defaut.md#user-content-54-soyez-transparent-sur-la-fa%C3%A7on-dont-vous-travaillez-et-justifiez-les-d%C3%A9cisions-que-vous-prenez)
+- [9.1 Adopter une approche équilibrée de gestion des risques en mettant en œuvre des mesures de sécurité et de confidentialité appropriées (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-91-adopter-une-approche-%C3%A9quilibr%C3%A9e-de-gestion-des-risques-en-mettant-en-%C5%93uvre-des-mesures-de-s%C3%A9curit%C3%A9-et-de-confidentialit%C3%A9-appropri%C3%A9es)
+- [9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-92-innover-et-sam%C3%A9liorer-tout-en-r%C3%A9pondant-aux-attentes-du-public-quant-%C3%A0-la-protection-de-la-confidentialit%C3%A9-des-donn%C3%A9es)
+- [9.3 Faites en sorte que la sécurité soit fluide et sans friction, en équilibrant sécurité et commodité (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-93-faites-en-sorte-que-la-s%C3%A9curit%C3%A9-soit-fluide-et-sans-friction-en-%C3%A9quilibrant-s%C3%A9curit%C3%A9-et-commodit%C3%A9)
+- [9.4 S'assurer que les services sont conformes à toutes les exigences législatives et réglementaires (Norme&#160;9&#160;: Aborder les risques de sécurité et de confidentialité)](9-aborder-risques-securite-confidentialite.md#user-content-94-sassurer-que-les-services-sont-conformes-%C3%A0-toutes-les-exigences-l%C3%A9gislatives-et-r%C3%A9glementaires)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 8.1 Soyez transparent au sujet des préjugés personnels et organisationnels et indiquez comment ils sont traités
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -77,7 +59,7 @@ altLangPage: 8-design-ethical-services
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -86,17 +68,17 @@ altLangPage: 8-design-ethical-services
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 8.2 Évaluer l'impact total sur les utilisateurs et les communautés
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -104,7 +86,7 @@ altLangPage: 8-design-ethical-services
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -113,17 +95,17 @@ altLangPage: 8-design-ethical-services
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 8.3 Se conformer aux directives éthiques dans la conception de systèmes automatisés
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -131,7 +113,7 @@ altLangPage: 8-design-ethical-services
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -140,17 +122,17 @@ altLangPage: 8-design-ethical-services
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 8.4 Équilibrer les compromis entre innovation et inclusivité
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -158,7 +140,7 @@ altLangPage: 8-design-ethical-services
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 

--- a/fr/8-concevoir-services-ethiques.md
+++ b/fr/8-concevoir-services-ethiques.md
@@ -15,8 +15,10 @@ altLangPage: 8-design-ethical-services
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 

--- a/fr/9-aborder-risques-securite-confidentialite.md
+++ b/fr/9-aborder-risques-securite-confidentialite.md
@@ -5,57 +5,46 @@ lang: fr
 altLang: en
 altLangPage: 9-address-security-privacy-risks
 ---
-<div markdown="1" class="dpgn-section-intro-standard">
+<div class="dpgn-section-intro-standard">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines">
+<div class="dpgn-section-guidelines">
 
 **Lignes directrices :**
 
-[9.1 Adopter une approche équilibrée de gestion des risques en mettant en œuvre des mesures de sécurité et de confidentialité appropriées](#user-content-91-adopter-une-approche-équilibrée-de-gestion-des-risques-en-mettant-en-œuvre-des-mesures-de-sécurité-et-de-confidentialité-appropriées)
-
-[9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données](#user-content-92-innover-et-saméliorer-tout-en-répondant-aux-attentes-du-public-quant-à-la-protection-de-la-confidentialité-des-données)
-
-[9.3 Faites en sorte que la sécurité soit fluide et sans friction, en équilibrant sécurité et commodité](#user-content-93-faites-en-sorte-que-la-sécurité-soit-fluide-et-sans-friction-en-équilibrant-sécurité-et-commodité)
-
-[9.4 S'assurer que les services sont conformes à toutes les exigences législatives et réglementaires](#user-content-94-sassurer-que-les-services-sont-conformes-à-toutes-les-exigences-législatives-et-réglementaires)
+- TOC
+{:toc}
 
 </div>
 
-<div markdown="1" class="dpgn-section-guidelines-related">
+<div class="dpgn-section-guidelines-related">
 
 **Lignes directrives connexes :**
 
-[1.5 Fournir des services qui peuvent être convertis n'importe où, n'importe où et n'importe quel appareil (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-15-fournir-des-services-qui-peuvent-%C3%AAtre-tout-quand-et-nimporte-quel-appareil)
-
-[1.6 Rendre les services simples, intuitifs et cohérents (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-16-rendre-les-services-simples-intuitifs-et-coh%C3%A9rents)
-
-[1.7 Rendre plus pratique et pratique l'utilisation des services numériques (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-17-rendre-plus-pratique-et-pratique-lutilisation-des-services-num%C3%A9riques)
-
-[6.1 Tirer parti des normes ouvertes et adopter des pratiques exemplaires (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-61-tirer-parti-des-normes-ouvertes-et-adopter-des-pratiques-exemplaires)
-
-[6.2 Utiliser et réutiliser des solutions, des approches et des plateformes gouvernementales communes et éprouvées (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-62-utiliser-et-r%C3%A9utiliser-des-solutions-des-approches-et-des-plates-formes-gouvernementales-courantes-et-%C3%A9prouv%C3%A9es)
-
-[8.3 Se conformer aux directives éthiques dans la conception de systèmes automatisés (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-83-se-conformer-aux-directives-%C3%A9thiques-dans-la-conception-de-syst%C3%A8mes-automatis%C3%A9s)
-
-[8.4 Équilibrer les compromis entre innovation et inclusivité (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-84-%C3%89quilibrer-les-compromis-entre-innovation-et-inclusivit%C3%A9)
+- [1.5 Fournir des services qui peuvent être convertis n'importe où, n'importe où et n'importe quel appareil (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-15-fournir-des-services-qui-peuvent-%C3%AAtre-tout-quand-et-nimporte-quel-appareil)
+- [1.6 Rendre les services simples, intuitifs et cohérents (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-16-rendre-les-services-simples-intuitifs-et-coh%C3%A9rents)
+- [1.7 Rendre plus pratique et pratique l'utilisation des services numériques (Norme&#160;1&#160;: Concevoir avec les utilisateurs)](1-concevoir-avec-utilisateurs.md#user-content-17-rendre-plus-pratique-et-pratique-lutilisation-des-services-num%C3%A9riques)
+- [6.1 Tirer parti des normes ouvertes et adopter des pratiques exemplaires (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-61-tirer-parti-des-normes-ouvertes-et-adopter-des-pratiques-exemplaires)
+- [6.2 Utiliser et réutiliser des solutions, des approches et des plateformes gouvernementales communes et éprouvées (Norme&#160;6&#160;: Utiliser des standards et solutions ouverts)](6-utiliser-standards-solutions-ouverts.md#user-content-62-utiliser-et-r%C3%A9utiliser-des-solutions-des-approches-et-des-plates-formes-gouvernementales-courantes-et-%C3%A9prouv%C3%A9es)
+- [8.3 Se conformer aux directives éthiques dans la conception de systèmes automatisés (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-83-se-conformer-aux-directives-%C3%A9thiques-dans-la-conception-de-syst%C3%A8mes-automatis%C3%A9s)
+- [8.4 Équilibrer les compromis entre innovation et inclusivité (Norme&#160;8&#160;: Concevoir des services éthiques)](8-concevoir-services-ethiques.md#user-content-84-%C3%89quilibrer-les-compromis-entre-innovation-et-inclusivit%C3%A9)
 
 </div>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 9.1 Adopter une approche équilibrée de gestion des risques en mettant en œuvre des mesures de sécurité et de confidentialité appropriées
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -65,7 +54,7 @@ altLangPage: 9-address-security-privacy-risks
 
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -78,11 +67,11 @@ altLangPage: 9-address-security-privacy-risks
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 9.2 Innover et s'améliorer tout en répondant aux attentes du public quant à la protection de la confidentialité des données
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -102,13 +91,13 @@ Users won't use a service unless they have a guarantee:
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -132,7 +121,7 @@ Users won't use a service unless they have a guarantee:
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -145,7 +134,7 @@ Users won't use a service unless they have a guarantee:
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -153,7 +142,7 @@ Users won't use a service unless they have a guarantee:
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -162,11 +151,11 @@ Users won't use a service unless they have a guarantee:
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 9.3 Faites en sorte que la sécurité soit fluide et sans friction, en équilibrant sécurité et commodité
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -185,7 +174,7 @@ Pour que les utilisateurs utilisent un service, il est nécessaire de garantir l
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -194,7 +183,7 @@ Pour que les utilisateurs utilisent un service, il est nécessaire de garantir l
 - Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
   - Embed all services in Pan-Canadian Trust Framework to foster multi-jurisdictional service delivery
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -224,7 +213,7 @@ Pour que les utilisateurs utilisent un service, il est nécessaire de garantir l
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -237,7 +226,7 @@ Pour que les utilisateurs utilisent un service, il est nécessaire de garantir l
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -245,7 +234,7 @@ Pour que les utilisateurs utilisent un service, il est nécessaire de garantir l
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 
@@ -254,11 +243,11 @@ Pour que les utilisateurs utilisent un service, il est nécessaire de garantir l
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guideline">
+<section class="dpgn-section-guideline">
 
 ## 9.4 S'assurer que les services sont conformes à toutes les exigences législatives et réglementaires
 
-<div markdown="1" class="dpgn-section-intro-guideline">
+<div class="dpgn-section-intro-guideline">
 
 **\[TODO: Ajouter / réviser le texte d'introduction\]**
 
@@ -291,7 +280,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 </div>
 
-<section markdown="1" class="dpgn-section-checklist">
+<section class="dpgn-section-checklist">
 
 ### Liste de contrôle
 
@@ -316,7 +305,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 - HTTPS only **(Build It Right - OneGC Architectural Checklist (draft))**
   - Holistic approach to securing GC services for publicly accessible sites
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-alpha">
+<section class="dpgn-section-stage dpgn-phase-alpha">
 
 #### Stage alpha
 
@@ -359,7 +348,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-beta">
+<section class="dpgn-section-stage dpgn-phase-beta">
 
 #### Stage bêta
 
@@ -404,7 +393,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 </section>
 
-<section markdown="1" class="dpgn-section-stage dpgn-phase-live">
+<section class="dpgn-section-stage dpgn-phase-live">
 
 #### Stage en direct
 
@@ -433,7 +422,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 </section>
 </section>
 
-<section markdown="1" class="dpgn-section-guides">
+<section class="dpgn-section-guides">
 
 ### Guides d'implémentation
 
@@ -451,7 +440,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 
 </section>
 
-<section markdown="1" class="dpgn-section-similar">
+<section class="dpgn-section-similar">
 
 ### Ressources similaires
 

--- a/fr/9-aborder-risques-securite-confidentialite.md
+++ b/fr/9-aborder-risques-securite-confidentialite.md
@@ -15,8 +15,10 @@ altLangPage: 9-address-security-privacy-risks
 
 **Lignes directrices :**
 
+<!-- markdownlint-disable MD032 -->
 - TOC
 {:toc}
+<!-- markdownlint-enable MD032 -->
 
 </div>
 


### PR DESCRIPTION
- Enabled HTML block parsing and set ToC generation to only level 2 headings
- Also removed markdown="1" since no longer needed