### PR TITLE
Fixed French pagination

### DIFF
--- a/fr/2-integrer-accessibilite-des-depart.md
+++ b/fr/2-integrer-accessibilite-des-depart.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  "2. Intégrer l’accessibilité dès le départ"
+title:  "2. Intégrer l’accessibilité dès le départ (ébauche)"
 lang: fr
 altLang: en
 altLangPage: 2-build-in-accessibility-from-start


### PR DESCRIPTION
- Added missing draft reference in the standard 2 French title which was tricking the pagination (since title in the dataset didn't match the title in the markdown file)