### PR TITLE
Added exclusive filter for OneGC architectural

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -329,7 +329,8 @@ GCWordmark:
   en: Symbol of the Government of Canada
   fr: Symbole du gouvernement du Canada
 
-# Filter translations
+# Filter strings
+DefaultTag: "dpgn-tags" # Output as a class for any element that has a tag array (empty or not)
 Filters:
   en: Filters
   fr: Filtres
@@ -372,6 +373,12 @@ ApplyFilters:
 RememberFilters:
   en: Remember my filters next time
   fr: Rappeler les filtres la prochaine fois
+ExclusiveFilters:
+  en: Exclusive filters
+  fr: Filtres exclusifs
+OneGCArchitectural:
+  en: OneGC Architectural Checklist
+  fr: Liste de contrôle architecturale unGC
 
 # Feedback and view source translations
 PageColon:

--- a/_includes/filter-interface.html
+++ b/_includes/filter-interface.html
@@ -32,6 +32,12 @@ assign guideline = standard.guidelines.content.first %}
     </li>
   </ul>
 </fieldset>
+<fieldset class="dpgn-exclusive-filters">
+  <legend>{{ site.ExclusiveFilters[page.lang] }}</legend>
+  <ul class="list-unstyled">
+    <li><input type="checkbox" id="dpgn-onegc-architectural" /> <label for="dpgn-onegc-architectural">{{ site.OneGCArchitectural[page.lang] }}</label></li>
+  </ul>
+</fieldset>
 <hr />
 <div><input type="checkbox" id="filters-remember" /> <label for="filters-remember">{{ site.RememberFilters:[page.lang] }}</label></div>
 <input type="button" value="{{ site.ApplyFilters[page.lang] }}" id="filter-button" class="btn btn-primary" />

--- a/en/1-design-with-users.md
+++ b/en/1-design-with-users.md
@@ -152,7 +152,7 @@ A key part of building digital services that work for users is developing a good
 
 **[TODO: Add/revise checklist items]**
 
-- Clearly defined user needs **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Clearly defined user needs **(Build It Right - OneGC Architectural Checklist (draft))**
   - User research, requirements and usability testing must be incorporated and tracked from the very beginning of any digital project
 
 <section class="dpgn-section-stage dpgn-phase-alpha">
@@ -247,7 +247,7 @@ A key part of building digital services that work for users is developing a good
 - Stakeholders/Users requirements based solutions (Current GC EARB Principles)
 - Services & client orientation (Current GC EARB Principles)
 - Business User first (GC EA principles)
-- Clearly defined user needs (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Clearly defined user needs (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -310,7 +310,7 @@ We need to understand the different ways people will interact with our services,
 **[TODO: Add/revise checklist items]**
 
 - Ensure that services are designed for the mobile digital channel first, and then adapted to other service channels. Refer to the related technical standard. **(General design principles - Digital Design Playbook (ISED))**
-- Platform agnostic **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Platform agnostic **(Build It Right - OneGC Architectural Checklist (draft))**
   - Build applications for easy deployment and portability regardless of platform/operating system by default (e.g., open standard containers)
 
 </section>
@@ -330,7 +330,7 @@ We need to understand the different ways people will interact with our services,
 - [Digital by design, optimized for mobile (General design principles - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/Digital_Design_Playbook)
 - Mobility Preferred (Current GC EARB Principles)
 - Any Device - Mobility (GC EA principles)
-- Platform agnostic (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Platform agnostic (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/en/10-be-good-data-stewards.md
+++ b/en/10-be-good-data-stewards.md
@@ -309,7 +309,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 **[TODO: Add/revise checklist items]**
 
-- Data is the new gold **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Data is the new gold **(Build It Right - OneGC Architectural Checklist (draft))**
   - Make certain that data is complete, authoritative, accurate, and timely to ensure a high level of data quality
   - Ensure data is able to be shared and can be easily accessed
 
@@ -336,7 +336,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 ### Similar resources
 
 - Information/Data is an asset (Current GC EARB Principles)
-- Data is the new gold (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Data is the new gold (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/en/3-collaborate-widely.md
+++ b/en/3-collaborate-widely.md
@@ -298,8 +298,8 @@ Good government services are built quickly and iteratively, based on user needs.
 
 ### Similar resources
 
-- [Open Source Code - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/4_Open_Source_Code.md)
-- [Open Culture - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/6_Open_Culture.md)
+- [Open Source Code - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/en/4_Open_Source_Code.md)
+- [Open Culture - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/en/6_Open_Culture.md)
 - [8. Make all new source code open (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/make-all-new-source-code-open)
 - [13. Default to open (Digital Services Playbook (US))](https://playbook.cio.gov/#play13)
 - [8. Make source code open (Digital Service Standard (AU))](https://www.dta.gov.au/standard/8-make-source-code-open/)

--- a/en/5-work-in-open-by-default.md
+++ b/en/5-work-in-open-by-default.md
@@ -218,7 +218,7 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 ### Similar resources
 
-- [Open Markets - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/5_Open_Markets.md)
+- [Open Markets - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/en/5_Open_Markets.md)
 - [2. Share best practices (Plan - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Plan#2._Share_best_practices)
 
 </section>
@@ -333,8 +333,8 @@ Open source helps to:
 
 ### Similar resources
 
-- [Open Source Code - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/4_Open_Source_Code.md)
-- [Open Culture - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/6_Open_Culture.md)
+- [Open Source Code - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/en/4_Open_Source_Code.md)
+- [Open Culture - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/en/6_Open_Culture.md)
 - [8. Make all new source code open (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/make-all-new-source-code-open)
 - [13. Default to open (Digital Services Playbook (US))](https://playbook.cio.gov/#play13)
 - [8. Make source code open (Digital Service Standard (AU))](https://www.dta.gov.au/standard/8-make-source-code-open/)

--- a/en/5-work-in-open-by-default.md
+++ b/en/5-work-in-open-by-default.md
@@ -271,7 +271,7 @@ Open source helps to:
 - When appropriate, create an API for third parties and internal users to interact with the service directly **(Digital Services Playbook (US))**
 - Make all new source code open and reusable and explain how it can be reused
 - Show your code in an open Internet source code repository and enable contributions and comments on the code
-- Build and develop open **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Build and develop open **(Build It Right - OneGC Architectural Checklist (draft))**
   - Actively use and contribute to open source tools and solutions
   - Develop in the open by sharing and reusing all types of code and platform configuration
 
@@ -339,7 +339,7 @@ Open source helps to:
 - [13. Default to open (Digital Services Playbook (US))](https://playbook.cio.gov/#play13)
 - [8. Make source code open (Digital Service Standard (AU))](https://www.dta.gov.au/standard/8-make-source-code-open/)
 - Open By Default, Proprietary by Necessity (Current GC EARB Principles)
-- Build and develop open (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Build and develop open (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/en/6-use-open-standards-solutions.md
+++ b/en/6-use-open-standards-solutions.md
@@ -75,8 +75,8 @@ Using open standards and common government platforms helps you to:
 
 - use open standards and common platforms **(Digital Service Standard (Ontario))**
 - understand common user needs with other services and meet those needs consistently with the rest of government **(Digital Service Standard (Ontario))**
-- Use emerging technologies **(Build It Right - OneGC Architectural Checklist (draft))**
-  - Leverage new technologies (e.g., AI and blockchain) to shift investments to more modern tec
+- {: .dpgn-onegc-architectural } Use emerging technologies **(Build It Right - OneGC Architectural Checklist (draft))**
+  - Leverage new technologies (e.g., AI and blockchain) to shift investments to more modern tech
 
 <section class="dpgn-section-stage dpgn-phase-alpha">
 
@@ -109,7 +109,6 @@ Using open standards and common government platforms helps you to:
 - [Working with open standards](https://www.gov.uk/service-manual/making-software/open-standards-and-licensing.html) **(Digital Service Standard (UK))**
 - [Technology for services](https://www.gov.uk/service-manual/technology/choosing-technology-an-introduction) **(Digital Service Standard (UK))**
 - [Australian Government ICT Policy Guides and Procurement](http://finance.gov.au/policy-guides-procurement/)
-
 - [W3C Standards](https://www.w3.org/standards/)
   - [Web Design and ApplicationsW3C Web design standards](https://www.w3.org/standards/webdesign/) **(W3C)**
   - [Web of Devices](https://www.w3.org/standards/webofdevices/) **(W3C)**
@@ -126,7 +125,7 @@ Using open standards and common government platforms helps you to:
 - [9. Use open standards and common platforms (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-10)
 - [7. Use open standards and common platforms (Digital Service Standard (AU))](https://www.dta.gov.au/standard/7-open-standards-and-common-platforms/)
 - Open Source Standards (GC EA Principles)
-- Use emerging technologies (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Use emerging technologies (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -155,14 +154,14 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 - Whenever possible, ensure that software can be deployed on a variety of commodity hardware types **(Digital Services Playbook (US))**
 - Ensure that each project has clear, understandable instructions for setting up a local development environment, and that team members can be quickly added or removed from projects **(Digital Services Playbook (US))**
 - [Consider open source software solutions](https://www.obamawhitehouse.gov/sites/default/files/omb/assets/egov_docs/memotociostechnologyneutrality.pdf) at every layer of the stack **(Digital Services Playbook (US))**
-- Build standards-based solution **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Build standards-based solution **(Build It Right - OneGC Architectural Checklist (draft))**
   - Adhere to GC technical standards and guidance, leveraging open standards when possible
   - Leverage common business capabilities and harness GC-wide solutions that can be reused across the enterprise
-- Digital Exchange Platform (DXP) **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Digital Exchange Platform (DXP) **(Build It Right - OneGC Architectural Checklist (draft))**
   - Mandatory use of DXP (Canada’s XRoad) to foster seamless service delivery
-- Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
   - Embed all services in Pan-Canadian Trust Framework to foster multi-jurisdictional service delivery
-- Build toward OneGC **Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Build toward OneGC **Build It Right - OneGC Architectural Checklist (draft))**
   - OneGC is where Digital business changes are built to support a government as a platform where everyone can maximise shared capability (Platforms) and minimise unique department products
 - Use departmental/GC standards. **(2. Reuse, improve and share technological solutions where appropriate (Do - Digital Design Playbook (ISED)))**
   - Adopt the business number as the client identifier - do not create other unique identifiers. This enables data sharing across service lines, departments and jurisdictions.
@@ -209,10 +208,10 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 - Technology Debt Managed (Current GC EARB Principles)
 - Containerized by default - Platform Independence Lift & Shift (GC EA Principles)
 - Architecturally Fit for the GC Enterprise (GC EA Principles)
-- Build standards-based solution (OneGC Architectural Checklist - Build It Right (draft))
-- Digital Exchange Platform (DXP) (OneGC Architectural Checklist - Build It Right (draft))
-- Pan-Canadian Trust Framework (OneGC Architectural Checklist - Build It Right (draft))
-- Build toward OneGC (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Build standards-based solution (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Digital Exchange Platform (DXP) (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Pan-Canadian Trust Framework (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Build toward OneGC (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -243,7 +242,7 @@ Application Program Interfaces (APIs) are a means by which business functionalit
 - Design APIs to have clear and simple semantics to make common tasks easy. Rare tasks should still be possible but not the focus. Avoid being overly general, optimizing specific use cases.
 - Design APIs to be intuitive so that a semi-experienced user can be successful with minimal assistance from the documentation and programmers can easily understand code that uses the API.
 - Design APIs to be easy to memorize by implementing a consistent and precise naming convention. Use plain language and recognizable patterns and concepts, avoiding abbreviations where possible.
-- API first **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } API first **(Build It Right - OneGC Architectural Checklist (draft))**
   - APIs created for every service, exposing data and functionality, to foster data sharing within GC and externally
   - Build microservices that work together within an ecosystem allowing for rapid deployment and built-in redundancy
 
@@ -267,7 +266,7 @@ Application Program Interfaces (APIs) are a means by which business functionalit
 
 - Interoperability (Current GC EARB Principles)
 - Interoperability (ESB/APIs - Micro Services) (GC EA Principles)
-- API first (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } API first (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -415,8 +414,6 @@ Public cloud services offer benefits that enable significant advances in the fol
 - Innovation: New features are being continuously deployed, and the costs are amortized across a global service customer base. New technologies such as social media, mobile platforms and analytic tools are all available through subscriptions without large capital investments.
 - Agility: Rapid access is available to multi-featured computing resources at the required capacity to carry out projects from planning to full operation.
 - Elasticity: Commoditized services can grow and shrink with the level of demand; consumers pay only for what is needed for the time it is needed.
-- Cloud first **(Build It Right - OneGC Architectural Checklist (draft))**
-  - SaaS considered first, PaaS, IaaS second to grow more modern infrastructure which includes public, private and hybrid cloud solutions
 
 </div>
 
@@ -433,6 +430,8 @@ Public cloud services offer benefits that enable significant advances in the fol
 - Design so static assets are served through a content delivery network **(OneGC product design criteria) /** Static assets are served through a content delivery network **(Digital Services Playbook (US))**
 - Resources are provisioned through an API **(Digital Services Playbook (US))**
 - Application is hosted on commodity hardware **(Digital Services Playbook (US))**
+- {: .dpgn-onegc-architectural } Cloud first **(Build It Right - OneGC Architectural Checklist (draft))**
+  - SaaS considered first, PaaS, IaaS second to grow more modern infrastructure which includes public, private and hybrid cloud solutions
 
 </section>
 
@@ -451,7 +450,7 @@ Public cloud services offer benefits that enable significant advances in the fol
 - [9. Deploy in a flexible hosting environment (Digital Services Playbook (US))](https://playbook.cio.gov/#play9)
 - Cloud First (Current GC EARB Principles)
 - (Public) Cloud First: SaaS - PaaS - IaaS (GC EA Principles)
-- Cloud first (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Cloud first (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/en/6-use-open-standards-solutions.md
+++ b/en/6-use-open-standards-solutions.md
@@ -120,7 +120,7 @@ Using open standards and common government platforms helps you to:
 
 ### Similar resources
 
-- [Open Standards - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/2_Open_Standards.md)
+- [Open Standards - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/en/2_Open_Standards.md)
 - [9. Use open standards and common platforms (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/use-open-standards-and-common-platforms)
 - [9. Use open standards and common platforms (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-10)
 - [7. Use open standards and common platforms (Digital Service Standard (AU))](https://www.dta.gov.au/standard/7-open-standards-and-common-platforms/)
@@ -199,7 +199,7 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 
 ### Similar resources
 
-- [Open Source Software - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/2_Open_Standards.md)
+- [Open Source Software - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/en/3_Open_Source_Software.md)
 - [8. Choose a modern technology stack (Digital Services Playbook (US))](https://playbook.cio.gov/#play8)
 - [1. Comply with Government of Canada acts, policies, standards and directives (Plan - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Plan#1._Comply_with_Government_of_Canada_acts.2C_policies.2C_standards_and_directives)
 - [2. Reuse, improve and share technological solutions where appropriate (Do - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#2._Reuse.2C_improve_and_share_technological_solutions_where_appropriate)

--- a/en/7-iterate-improve-frequently.md
+++ b/en/7-iterate-improve-frequently.md
@@ -90,7 +90,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 **[TODO: Add/revise checklist items]**
 
-- Use agile **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Use agile **(Build It Right - OneGC Architectural Checklist (draft))**
   - Be an agile Developer: Develop in an iterative manner, with key stakeholders participation from the beginning, releasing minimum viable product as soon as possible and iteratively building out functionality
   - Be an agile administrator: Promote DEVOPS and automate, monitor and unify all platform and software construction from testing to release and infrastructure management
 
@@ -210,7 +210,7 @@ Start with a representation or prototype of the solution that will be tested and
 - [3. Review and improve services continually (Think - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Think#3._Review_and_improve_services_continually)
 - [3. Apply agile principles and be iterative. (Do - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#3._Apply_agile_principles_and_be_iterative.)
 - Agile - Small chunks - Iterate (GC EA Principles)
-- Use agile (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Use agile (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/en/9-address-security-privacy-risks.md
+++ b/en/9-address-security-privacy-risks.md
@@ -162,7 +162,7 @@ Users won't use a service unless they have a guarantee:
 
 **[TODO: Add/revise checklist items]**
 
-- Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
   - Embed all services in Pan-Canadian Trust Framework to foster multi-jurisdictional service delivery
 
 <section class="dpgn-section-stage dpgn-phase-alpha">
@@ -210,7 +210,7 @@ Users won't use a service unless they have a guarantee:
 - [10. Embed privacy and security by design (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-11)
 - Secure by Design (Current GC EARB Principles)
 - Secure by Design (GC EA Principles)
-- Pan-Canadian Trust Framework (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Pan-Canadian Trust Framework (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -265,7 +265,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 - Consider whether the user should be able to access, delete, or remove their information from the service **(Digital Services Playbook (US))**
 - "Pre-certify" the hosting infrastructure used for the project using FedRAMP **(Digital Services Playbook (US))**
 - Use deployment scripts to ensure configuration of production environment remains consistent and controllable **(Digital Services Playbook (US))**
-- HTTPS only **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } HTTPS only **(Build It Right - OneGC Architectural Checklist (draft))**
   - Holistic approach to securing GC services for publicly accessible sites
 
 <section class="dpgn-section-stage dpgn-phase-alpha">
@@ -368,7 +368,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 - [7. Understand security and privacy issues (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/understand-security-and-privacy-issues)
 - [11. Manage security and privacy through reusable processes (Digital Services Playbook (US))](https://playbook.cio.gov/#play11)
 - [5. Make it secure (Digital Service Standard (AU))](https://www.dta.gov.au/standard/5-make-it-secure/)
-- HTTPS only (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } HTTPS only (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/fr/1-concevoir-avec-utilisateurs.md
+++ b/fr/1-concevoir-avec-utilisateurs.md
@@ -150,7 +150,7 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-- Clearly defined user needs **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Clearly defined user needs **(Build It Right - OneGC Architectural Checklist (draft))**
   - User research, requirements and usability testing must be incorporated and tracked from the very beginning of any digital project
 
 <section class="dpgn-section-stage dpgn-phase-alpha">
@@ -245,7 +245,7 @@ Un élément clé du développement de services numériques qui fonctionnent pou
 - Stakeholders/Users requirements based solutions (Current GC EARB Principles)
 - Services & client orientation (Current GC EARB Principles)
 - Business User first (GC EA principles)
-- Clearly defined user needs (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Clearly defined user needs (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -309,7 +309,7 @@ We need to understand the different ways people will interact with our services,
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
 - Ensure that services are designed for the mobile digital channel first, and then adapted to other service channels. Refer to the related technical standard. **(General design principles - Digital Design Playbook (ISED))**
-- Platform agnostic **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Platform agnostic **(Build It Right - OneGC Architectural Checklist (draft))**
   - Build applications for easy deployment and portability regardless of platform/operating system by default (e.g., open standard containers)
 
 </section>
@@ -329,7 +329,7 @@ We need to understand the different ways people will interact with our services,
 - [Digital by design, optimized for mobile (General design principles - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/Digital_Design_Playbook)
 - Mobility Preferred (Current GC EARB Principles)
 - Any Device - Mobility (GC EA principles)
-- Platform agnostic (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Platform agnostic (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/fr/10-etre-bons-utilisateurs-donnees.md
+++ b/fr/10-etre-bons-utilisateurs-donnees.md
@@ -309,7 +309,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-- Data is the new gold **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Data is the new gold **(Build It Right - OneGC Architectural Checklist (draft))**
   - Make certain that data is complete, authoritative, accurate, and timely to ensure a high level of data quality
   - Ensure data is able to be shared and can be easily accessed
 
@@ -328,7 +328,7 @@ Every service must aim for continuous improvement. Metrics are an important star
 ### Similar resources
 
 - Information/Data is an asset (Current GC EARB Principles)
-- Data is the new gold (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Data is the new gold (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/fr/3-collaborer-largement.md
+++ b/fr/3-collaborer-largement.md
@@ -300,8 +300,8 @@ Good government services are built quickly and iteratively, based on user needs.
 
 ### Ressources similaires
 
-- [Open Source Code - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/4_Open_Source_Code.md)
-- [Open Culture - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/6_Open_Culture.md)
+- [Code source ouvert - Livre blanc ouvert en premier (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/fr/4_Code_source_libre.md)
+- [Culture ouverte - Livre blanc ouvert en premier (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/fr/6_Culture_ouverte.md)
 - [8. Make all new source code open (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/make-all-new-source-code-open)
 - [13. Default to open (Digital Services Playbook (US))](https://playbook.cio.gov/#play13)
 - [8. Make source code open (Digital Service Standard (AU))](https://www.dta.gov.au/standard/8-make-source-code-open/)

--- a/fr/5-travailler-ouvertement-par-defaut.md
+++ b/fr/5-travailler-ouvertement-par-defaut.md
@@ -218,7 +218,7 @@ Share your experiences with colleagues across the Government of Canada, other le
 
 ### Ressources similaires
 
-- [Open Markets - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/5_Open_Markets.md)
+- [Marchés ouverts - Livre blanc ouvert en premier (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/fr/5_March%C3%A9s_ouverts.md)
 - [2. Share best practices (Plan - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Plan#2._Share_best_practices)
 
 </section>
@@ -329,8 +329,8 @@ Open source helps to:
 
 ### Ressources similaires
 
-- [Open Source Code - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/4_Open_Source_Code.md)
-- [Open Culture - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/6_Open_Culture.md)
+- [Code source ouvert - Livre blanc ouvert en premier (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/fr/4_Code_source_libre.md)
+- [Culture ouverte - Livre blanc ouvert en premier (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/fr/6_Culture_ouverte.md)
 - [8. Make all new source code open (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/make-all-new-source-code-open)
 - [13. Default to open (Digital Services Playbook (US))](https://playbook.cio.gov/#play13)
 - [8. Make source code open (Digital Service Standard (AU))](https://www.dta.gov.au/standard/8-make-source-code-open/)

--- a/fr/5-travailler-ouvertement-par-defaut.md
+++ b/fr/5-travailler-ouvertement-par-defaut.md
@@ -267,7 +267,7 @@ Open source helps to:
 - When appropriate, create an API for third parties and internal users to interact with the service directly **(Digital Services Playbook (US))**
 - Make all new source code open and reusable and explain how it can be reused
 - Show your code in an open Internet source code repository and enable contributions and comments on the code
-- Build and develop open **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Build and develop open **(Build It Right - OneGC Architectural Checklist (draft))**
   - Actively use and contribute to open source tools and solutions
   - Develop in the open by sharing and reusing all types of code and platform configuration
 
@@ -335,7 +335,7 @@ Open source helps to:
 - [13. Default to open (Digital Services Playbook (US))](https://playbook.cio.gov/#play13)
 - [8. Make source code open (Digital Service Standard (AU))](https://www.dta.gov.au/standard/8-make-source-code-open/)
 - Open By Default, Proprietary by Necessity (Current GC EARB Principles)
-- Build and develop open (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Build and develop open (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/fr/6-utiliser-normes-solutions-ouvertes.md
+++ b/fr/6-utiliser-normes-solutions-ouvertes.md
@@ -75,7 +75,7 @@ Using open standards and common government platforms helps you to:
 
 - use open standards and common platforms **(Digital Service Standard (Ontario))**
 - understand common user needs with other services and meet those needs consistently with the rest of government **(Digital Service Standard (Ontario))**
-- Use emerging technologies **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Use emerging technologies **(Build It Right - OneGC Architectural Checklist (draft))**
   - Leverage new technologies (e.g., AI and blockchain) to shift investments to more modern tec
 
 <section class="dpgn-section-stage dpgn-phase-alpha">
@@ -125,7 +125,7 @@ Using open standards and common government platforms helps you to:
 - [9. Utiliser des normes ouvertes et des plateformes communes (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-10)
 - [7. Use open standards and common platforms (Digital Service Standard (AU))](https://www.dta.gov.au/standard/7-open-standards-and-common-platforms/)
 - Open Source Standards (GC EA Principles)
-- Use emerging technologies (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Use emerging technologies (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -154,14 +154,14 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 - Whenever possible, ensure that software can be deployed on a variety of commodity hardware types **(Digital Services Playbook (US))**
 - Ensure that each project has clear, understandable instructions for setting up a local development environment, and that team members can be quickly added or removed from projects **(Digital Services Playbook (US))**
 - [Consider open source software solutions](https://www.obamawhitehouse.gov/sites/default/files/omb/assets/egov_docs/memotociostechnologyneutrality.pdf) at every layer of the stack **(Digital Services Playbook (US))**
-- Build standards-based solution **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Build standards-based solution **(Build It Right - OneGC Architectural Checklist (draft))**
   - Adhere to GC technical standards and guidance, leveraging open standards when possible
   - Leverage common business capabilities and harness GC-wide solutions that can be reused across the enterprise
-- Digital Exchange Platform (DXP) **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Digital Exchange Platform (DXP) **(Build It Right - OneGC Architectural Checklist (draft))**
   - Mandatory use of DXP (Canada’s XRoad) to foster seamless service delivery
-- Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
   - Embed all services in Pan-Canadian Trust Framework to foster multi-jurisdictional service delivery
-- Build toward OneGC **Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Build toward OneGC **Build It Right - OneGC Architectural Checklist (draft))**
   - OneGC is where Digital business changes are built to support a government as a platform where everyone can maximise shared capability (Platforms) and minimise unique department products
 - Use departmental/GC standards. **(2. Reuse, improve and share technological solutions where appropriate (Do - Digital Design Playbook (ISED)))**
   - Adopt the business number as the client identifier - do not create other unique identifiers. This enables data sharing across service lines, departments and jurisdictions.
@@ -208,10 +208,10 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 - Technology Debt Managed (Current GC EARB Principles)
 - Containerized by default - Platform Independence Lift & Shift (GC EA Principles)
 - Architecturally Fit for the GC Enterprise (GC EA Principles)
-- Build standards-based solution (OneGC Architectural Checklist - Build It Right (draft))
-- Digital Exchange Platform (DXP) (OneGC Architectural Checklist - Build It Right (draft))
-- Pan-Canadian Trust Framework (OneGC Architectural Checklist - Build It Right (draft))
-- Build toward OneGC (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Build standards-based solution (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Digital Exchange Platform (DXP) (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Pan-Canadian Trust Framework (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Build toward OneGC (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -240,7 +240,7 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 - Design APIs to have clear and simple semantics to make common tasks easy. Rare tasks should still be possible but not the focus. Avoid being overly general, optimizing specific use cases.
 - Design APIs to be intuitive so that a semi-experienced user can be successful with minimal assistance from the documentation and programmers can easily understand code that uses the API.
 - Design APIs to be easy to memorize by implementing a consistent and precise naming convention. Use plain language and recognizable patterns and concepts, avoiding abbreviations where possible.
-- API first **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } API first **(Build It Right - OneGC Architectural Checklist (draft))**
   - APIs created for every service, exposing data and functionality, to foster data sharing within GC and externally
   - Build microservices that work together within an ecosystem allowing for rapid deployment and built-in redundancy
 
@@ -264,7 +264,7 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 
 - Interoperability (Current GC EARB Principles)
 - Interoperability (ESB/APIs - Micro Services) (GC EA Principles)
-- API first (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } API first (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -407,8 +407,6 @@ Public cloud services offer benefits that enable significant advances in the fol
 - Innovation: New features are being continuously deployed, and the costs are amortized across a global service customer base. New technologies such as social media, mobile platforms and analytic tools are all available through subscriptions without large capital investments.
 - Agility: Rapid access is available to multi-featured computing resources at the required capacity to carry out projects from planning to full operation.
 - Elasticity: Commoditized services can grow and shrink with the level of demand; consumers pay only for what is needed for the time it is needed.
-- Cloud first **(Build It Right - OneGC Architectural Checklist (draft))**
-  - SaaS considered first, PaaS, IaaS second to grow more modern infrastructure which includes public, private and hybrid cloud solutions
 
 </div>
 
@@ -425,6 +423,8 @@ Public cloud services offer benefits that enable significant advances in the fol
 - Design so static assets are served through a content delivery network **(OneGC product design criteria) /** Static assets are served through a content delivery network **(Digital Services Playbook (US))**
 - Resources are provisioned through an API **(Digital Services Playbook (US))**
 - Application is hosted on commodity hardware **(Digital Services Playbook (US))**
+- {: .dpgn-onegc-architectural } Cloud first **(Build It Right - OneGC Architectural Checklist (draft))**
+  - SaaS considered first, PaaS, IaaS second to grow more modern infrastructure which includes public, private and hybrid cloud solutions
 
 </section>
 
@@ -443,7 +443,7 @@ Public cloud services offer benefits that enable significant advances in the fol
 - [9. Deploy in a flexible hosting environment (Digital Services Playbook (US))](https://playbook.cio.gov/#play9)
 - Cloud First (Current GC EARB Principles)
 - (Public) Cloud First: SaaS - PaaS - IaaS (GC EA Principles)
-- Cloud first (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Cloud first (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/fr/6-utiliser-normes-solutions-ouvertes.md
+++ b/fr/6-utiliser-normes-solutions-ouvertes.md
@@ -120,7 +120,7 @@ Using open standards and common government platforms helps you to:
 
 ### Ressources similaires
 
-- [Open Standards - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/2_Open_Standards.md)
+- [Normes ouvertes - Livre blanc ouvert en premier (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/fr/2_Normes_ouvertes.md)
 - [9. Use open standards and common platforms (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/use-open-standards-and-common-platforms)
 - [9. Utiliser des normes ouvertes et des plateformes communes (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-10)
 - [7. Use open standards and common platforms (Digital Service Standard (AU))](https://www.dta.gov.au/standard/7-open-standards-and-common-platforms/)
@@ -199,7 +199,7 @@ In order to limit costs, avoid duplication of effort and provide a consistent cl
 
 ### Ressources similaires
 
-- [Open Source Software - Open First Whitepaper (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/2_Open_Standards.md)
+- [Code source ouvert - Livre blanc ouvert en premier (GC)](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/fr/4_Code_source_libre.md)
 - [8. Choose a modern technology stack (Digital Services Playbook (US))](https://playbook.cio.gov/#play8)
 - [1. Comply with Government of Canada acts, policies, standards and directives (Plan - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Plan#1._Comply_with_Government_of_Canada_acts.2C_policies.2C_standards_and_directives)
 - [2. Reuse, improve and share technological solutions where appropriate (Do - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#2._Reuse.2C_improve_and_share_technological_solutions_where_appropriate)

--- a/fr/7-effectuer-iterations-ameliorations-constamment.md
+++ b/fr/7-effectuer-iterations-ameliorations-constamment.md
@@ -90,7 +90,7 @@ Start with a representation or prototype of the solution that will be tested and
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-- Use agile **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Use agile **(Build It Right - OneGC Architectural Checklist (draft))**
   - Be an agile Developer: Develop in an iterative manner, with key stakeholders participation from the beginning, releasing minimum viable product as soon as possible and iteratively building out functionality
   - Be an agile administrator: Promote DEVOPS and automate, monitor and unify all platform and software construction from testing to release and infrastructure management
 
@@ -210,7 +210,7 @@ Start with a representation or prototype of the solution that will be tested and
 - [3. Review and improve services continually (Think - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Think#3._Review_and_improve_services_continually)
 - [3. Apply agile principles and be iterative. (Do - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#3._Apply_agile_principles_and_be_iterative.)
 - Agile - Small chunks - Iterate (GC EA Principles)
-- Use agile (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Use agile (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>

--- a/fr/9-gerer-risques-matiere-securite-protection-renseignements-personnels.md
+++ b/fr/9-gerer-risques-matiere-securite-protection-renseignements-personnels.md
@@ -24,7 +24,7 @@ altLangPage: 9-address-security-privacy-risks
 
 <div class="dpgn-section-guidelines-related">
 
-**Lignes directrives connexes :**
+**Lignes directives connexes :**
 
 {% include functions/guideline-links.html guidelines="1.5, 1.6, 1.7, 6.1, 6.2, 8.3, 8.4" samePage=false standardTitle=page.title %}
 
@@ -162,7 +162,7 @@ Pour que les utilisateurs utilisent un service, il est nécessaire de garantir l
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-- Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } Pan-Canadian Trust Framework **(Build It Right - OneGC Architectural Checklist (draft))**
   - Embed all services in Pan-Canadian Trust Framework to foster multi-jurisdictional service delivery
 
 <section class="dpgn-section-stage dpgn-phase-alpha">
@@ -210,7 +210,7 @@ Pour que les utilisateurs utilisent un service, il est nécessaire de garantir l
 - [10. Intégrer la sécurité et la protection de la vie privée au niveau de la conception (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-11)
 - Secure by Design (Current GC EARB Principles)
 - Secure by Design (GC EA Principles)
-- Pan-Canadian Trust Framework (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } Pan-Canadian Trust Framework (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>
@@ -265,7 +265,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 - Consider whether the user should be able to access, delete, or remove their information from the service **(Digital Services Playbook (US))**
 - "Pre-certify" the hosting infrastructure used for the project using FedRAMP **(Digital Services Playbook (US))**
 - Use deployment scripts to ensure configuration of production environment remains consistent and controllable **(Digital Services Playbook (US))**
-- HTTPS only **(Build It Right - OneGC Architectural Checklist (draft))**
+- {: .dpgn-onegc-architectural } HTTPS only **(Build It Right - OneGC Architectural Checklist (draft))**
   - Holistic approach to securing GC services for publicly accessible sites
 
 <section class="dpgn-section-stage dpgn-phase-alpha">
@@ -368,7 +368,7 @@ If a service cannot guarantee confidentiality, integrity and availability of the
 - [7. Understand security and privacy issues (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/understand-security-and-privacy-issues)
 - [11. Manage security and privacy through reusable processes (Digital Services Playbook (US))](https://playbook.cio.gov/#play11)
 - [5. Make it secure (Digital Service Standard (AU))](https://www.dta.gov.au/standard/5-make-it-secure/)
-- HTTPS only (OneGC Architectural Checklist - Build It Right (draft))
+- {: .dpgn-onegc-architectural } HTTPS only (OneGC Architectural Checklist - Build It Right (draft))
 
 </section>
 </section>


### PR DESCRIPTION
- Added OneGC architectural tags to OneGC architectural checklist items
- Added exclusive filter for OneGC architectural tags (filters out everything but elements with the tags, the ancestors, descendants as well as headings).
- Fixed broken Open First Whitepaper links (pages moved)