### PR TITLE
Markdownlint package updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,12 +47,12 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "asynckit": {
@@ -87,15 +87,6 @@
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
       }
     },
     "brace-expansion": {
@@ -175,26 +166,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
-      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -343,24 +314,6 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "dev": true,
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
-      }
-    },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-      "dev": true
-    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -421,7 +374,7 @@
       "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "isstream": {
@@ -468,15 +421,15 @@
       }
     },
     "link-check": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/link-check/-/link-check-4.3.3.tgz",
-      "integrity": "sha512-JYZF6+31Mbq006FvoMbDbg3PpNmj5I9Hv2L9y7wtyR6PNolYKXXhlXDd1fk7eSnfJDiCs1LStL9j/ofmAos3nQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/link-check/-/link-check-4.4.1.tgz",
+      "integrity": "sha512-VOa3X8/skQAvXVSZi/rrOC/Ap89f6pLc+aIEl7LN0rI1JW48sS7yVJbY6FZRlWEdrtYng1fETAyaP/wf13ZnoA==",
       "dev": true,
       "requires": {
         "is-relative-url": "2.0.0",
         "isemail": "3.1.2",
         "ms": "2.1.1",
-        "request": "2.85.0"
+        "request": "2.87.0"
       }
     },
     "linkify-it": {
@@ -489,9 +442,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
     "lodash.differencewith": {
@@ -520,21 +473,32 @@
       }
     },
     "markdown-link-check": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.3.0.tgz",
-      "integrity": "sha1-/3+xHMfycXXwRQeHPLUBNs9pR3Q=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.5.0.tgz",
+      "integrity": "sha512-I8PH03tU8RupqDBsrpDJwajKPWwyAUKHAXYqE5egtIpHI4MJsqjYBhcdd4D46n7IJIEpbx/UGz+Djsp3+gR7uQ==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "chalk": "2.4.0",
+        "async": "2.6.1",
+        "chalk": "2.4.1",
         "commander": "2.15.1",
-        "link-check": "4.3.3",
-        "lodash": "4.17.5",
+        "link-check": "4.4.1",
+        "lodash": "4.17.10",
         "markdown-link-extractor": "1.1.1",
         "progress": "2.0.0",
-        "request": "2.85.0"
+        "request": "2.87.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
         "commander": {
           "version": "2.15.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
@@ -675,15 +639,15 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "rc": {
@@ -699,9 +663,9 @@
       }
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
@@ -712,7 +676,6 @@
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
         "har-validator": "5.0.3",
-        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
@@ -720,28 +683,18 @@
         "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
-    },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
-      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -764,12 +717,6 @@
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -809,7 +756,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,9 +206,9 @@
       }
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
       "dev": true
     },
     "delayed-stream": {
@@ -553,28 +553,28 @@
       }
     },
     "markdownlint": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.8.1.tgz",
-      "integrity": "sha512-1ppHJ0NUXL2TfigHJ+P94pqOMvMUpP86CQzlINpgK3zeRshykwsQuaAf2aQu9S8ZYkgJ+FB+iSo1OlrJsbhefw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.9.0.tgz",
+      "integrity": "sha512-oktat4knTTEV9adbw+PgCtUuNkHW66QYOqzmVnaOwgRyqUFseX278QYY+peinHM3qe8rgQfSQUOemFXtnoXZ1w==",
       "dev": true,
       "requires": {
         "markdown-it": "8.4.1"
       }
     },
     "markdownlint-cli": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.8.1.tgz",
-      "integrity": "sha512-1M/DrdV4JlL+V6L3GxM2MNgNeZ9qZP4yFisfyKdTO/mhJAsWd92ff8on8X5/NlUVH1XM5QD5qOiAXM/+SHFELA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.9.0.tgz",
+      "integrity": "sha512-Ftvv0HlngfsLXMZ6uVR8csGK7J0RdLZnSTuPFik00sFLI67hMwUm9SpmzAX3N7zJw8XIE6GrxGSletqv7A+S4Q==",
       "dev": true,
       "requires": {
         "commander": "2.9.0",
-        "deep-extend": "0.4.2",
+        "deep-extend": "0.5.1",
         "get-stdin": "5.0.1",
         "glob": "7.0.6",
         "lodash.differencewith": "4.5.0",
         "lodash.flatten": "4.4.0",
-        "markdownlint": "0.8.1",
-        "rc": "1.1.7"
+        "markdownlint": "0.9.0",
+        "rc": "1.2.7"
       },
       "dependencies": {
         "glob": {
@@ -687,12 +687,12 @@
       "dev": true
     },
     "rc": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-      "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
+        "deep-extend": "0.5.1",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "link-check": "node link-check.js",
-    "lint": "markdownlint \"*.md\" \"en/*.md\" \"fr/*.md\"",
+    "lint": "markdownlint -i node_modules \"**/*.md\"",
     "test": "npm run lint && npm run link-check"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "chalk": "^2.4.0",
     "glob": "^7.1.2",
-    "markdown-link-check": "^3.3.0",
+    "markdown-link-check": "^3.5.0",
     "markdownlint-cli": "^0.9.0"
   },
   "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chalk": "^2.4.0",
     "glob": "^7.1.2",
     "markdown-link-check": "^3.3.0",
-    "markdownlint-cli": "^0.8.1"
+    "markdownlint-cli": "^0.9.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Use the latest published versions of Markdownlint and Markdown-link-check.
Updated the file globbing to capture any new folders with markdown files that get added to the repo 