### PR TITLE
Markdowdow link check ignore patterns

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,16 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "http://intranet.canada.ca/"
+    },
+    {
+      "pattern": "http://www.gcpedia.gc.ca/"
+    }
+  ],
+  "replacementPatterns": [
+    {
+      "pattern": "https://canada-ca.github.io/digital-playbook-guide-numerique/",
+      "replacement": ""
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The Government of Canada Digital Playbook is available under the [Open Governmen
 - [Government of Canada Digital Playbook (draft) - Single page view](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/single-page-seule/en/digital-playbook.html)
 - [Government of Canada Digital Playbook (draft) - Multi-page view](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/standards-normes/en/overview.html)
 - [Development stages](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/dev-stages/en/development-stages.html)
-- [Development stages - Checklists only](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/development-stages/en/dev-stages-checklists-only.html)
+- [Development stages - Checklists only](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/dev-stages/en/development-stages-checklists-only.html)
 
 ## About the Digital Playbook
 

--- a/link-check.js
+++ b/link-check.js
@@ -9,15 +9,16 @@ var path = require("path");
 var url = require("url");
 var chalk = require("chalk");
 
-var internalGCHosts = ["www.gcpedia.gc.ca", "intranet.canada.ca"]
 var files = glob.sync("**/*.md", {ignore: ["node_modules/**/*.md", "**/digital-playbook.md", "**/guide-numerique.md"]})
 
 var deads = false;
 
+var opts = JSON.parse(fs.readFileSync(".markdown-link-check.json"));
+
+opts.baseUrl = "file://" + path.resolve(__dirname, "_site/").replace(/\\/g, '/') + "/"
+
 files.forEach(function(file) {
   var markdown = fs.readFileSync(file).toString();
-  var opts = {};
-  opts.baseUrl = 'file://' + path.dirname(path.resolve(file));
 
   markdownLinkCheck(markdown, opts, function (err, results) {
     if (err) {
@@ -29,17 +30,12 @@ files.forEach(function(file) {
 
     results.forEach(function (result) {
       if(result.status === "dead") {
-        var target = url.parse(result.link);
-
-        if(internalGCHosts.indexOf(target.hostname) == -1)
-        {
-          deads = true;
-          console.log(chalk.red("Dead: " + result.link));
-        } else if (result.statusCode == 500) {
+        if (result.statusCode == 500) {
           console.log(chalk.yellow("Server error on target: " + result.link));
         }
         else {
-          console.log(chalk.yellow("Internal GC link: " + result.link));
+          deads = true;
+          console.log(chalk.red("Dead: " + result.link));
         }
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -322,7 +322,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "sshpk": "1.14.2"
       }
     },
     "inflight": {
@@ -421,9 +421,9 @@
       }
     },
     "link-check": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/link-check/-/link-check-4.4.1.tgz",
-      "integrity": "sha512-VOa3X8/skQAvXVSZi/rrOC/Ap89f6pLc+aIEl7LN0rI1JW48sS7yVJbY6FZRlWEdrtYng1fETAyaP/wf13ZnoA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/link-check/-/link-check-4.4.3.tgz",
+      "integrity": "sha512-5YOZm4xqRgpJKriT3LJdLDqKd4D1BC37MSXquVkrzwQz69Wucgmg5C6kIn6vB90UgXeb2Pm2IxuLWirMRIKcFg==",
       "dev": true,
       "requires": {
         "is-relative-url": "2.0.0",
@@ -473,17 +473,17 @@
       }
     },
     "markdown-link-check": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.5.0.tgz",
-      "integrity": "sha512-I8PH03tU8RupqDBsrpDJwajKPWwyAUKHAXYqE5egtIpHI4MJsqjYBhcdd4D46n7IJIEpbx/UGz+Djsp3+gR7uQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.6.1.tgz",
+      "integrity": "sha512-nbe01S6LzFz8Fpqh9Z2kM3PnnJmRrNaYEECk6DJMme2BMfONRebtuyeDPz6EkR7Gt/Ak/Ug3flHPYtNK8WgKTA==",
       "dev": true,
       "requires": {
         "async": "2.6.1",
         "chalk": "2.4.1",
         "commander": "2.15.1",
-        "link-check": "4.4.1",
+        "link-check": "4.4.3",
         "lodash": "4.17.10",
-        "markdown-link-extractor": "1.1.1",
+        "markdown-link-extractor": "1.2.0",
         "progress": "2.0.0",
         "request": "2.87.0"
       },
@@ -508,12 +508,12 @@
       }
     },
     "markdown-link-extractor": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-1.1.1.tgz",
-      "integrity": "sha512-y6ucY1TIB4lBTUrhSU0R/2ncg2JeRyzUqFj/2juW7rB6fhlrGSG6IU0le1+GbBYiTlxM6pztut46bS9MPIeN1g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-1.2.0.tgz",
+      "integrity": "sha512-1unDsoZSSiF5oGFu/2y8M3E2I2YhWT/jiKGTQxa1IAmkC1OcyHo9OYNu3qCuVSj5Ty87+mFtgQxJPUfc08WirA==",
       "dev": true,
       "requires": {
-        "marked": "0.3.19"
+        "marked": "0.4.0"
       }
     },
     "markdownlint": {
@@ -558,9 +558,9 @@
       }
     },
     "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
       "dev": true
     },
     "mdurl": {
@@ -696,6 +696,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -703,9 +709,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "0.2.3",
@@ -715,6 +721,7 @@
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "chalk": "^2.4.0",
     "glob": "^7.1.2",
-    "markdown-link-check": "^3.5.0",
+    "markdown-link-check": "^3.6.1",
     "markdownlint-cli": "^0.9.0"
   },
   "dependencies": {}


### PR DESCRIPTION
Still can't quite use the native runner yet, but this uses the built in pattern ignoring and replacement.
Now uses the local Jekyll build site, so the build failures won't be caused by waiting for content to be published.