### PR TITLE
Enhanced view source links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -425,9 +425,12 @@ PageColon:
 FeedbackAsk:
   en: Give feedback about this page
   fr: Donnez votre avis sur cette page
-ViewSourceGitHub:
-  en: View source on GitHub
-  fr: Voir la source sur GitHub
+ViewContentSourceGitHub:
+  en: View content source on GitHub
+  fr: Voir la source du contenu sur GitHub
+ViewTemplateSourceGitHub:
+  en: View template source on GitHub
+  fr: Voir la source du modèle sur GitHub
 SubmitIssueGitHub:
   en: Submit an issue on GitHub
   fr: Soumettre un problème sur GitHub

--- a/_includes/page-options.html
+++ b/_includes/page-options.html
@@ -6,7 +6,7 @@
 {% else %}
   <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}">{{ site.ViewContentSourceGitHub[page.lang] }}</a></li>
 {% endif %}
-  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.path }}">{{ site.ViewOutputSourceGitHub[page.lang] }}</a></li>
+  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.path }}">{{ site.ViewTemplateSourceGitHub[page.lang] }}</a></li>
 {% assign overviewPath = page.lang | append: "/" | append: site.overviewFile[page.lang] %}{% 
 unless page.url contains overviewPath or page.url contains "compar" %}
   <li><p><a href="#filter-panel" aria-controls="filter-panel" class="overlay-lnk btn btn-primary" role="button">{{ site.ShowFilters[page.lang] }}</a></li>

--- a/_includes/page-options.html
+++ b/_includes/page-options.html
@@ -1,14 +1,19 @@
 <ul class="list-unstyled{% if include.alignment %} {{ include.alignment }}{% endif %}">
-  <li><a href="#feedback-popup" aria-controls="feedback-popup" class="wb-lbx" role="button">{{ site.FeedbackAsk[page.lang] }}</a></li>
-{% if page.path contains "standards-normes" %}{% 
-  assign pageIndex = page.standard | minus: 1 %}
-  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}/{{ site.standardFile[pageIndex][page.lang] }}.md">{{ site.ViewContentSourceGitHub[page.lang] }}</a></li>
-{% else %}
-  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}">{{ site.ViewContentSourceGitHub[page.lang] }}</a></li>
-{% endif %}
-  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.path }}">{{ site.ViewTemplateSourceGitHub[page.lang] }}</a></li>
-{% assign overviewPath = page.lang | append: "/" | append: site.overviewFile[page.lang] %}{% 
+  <li><a href="#feedback-popup" aria-controls="feedback-popup" class="wb-lbx" role="button">{{ site.FeedbackAsk[page.lang] }}</a></li>{% 
+if page.path contains "standards-normes" %}{% 
+  assign overviewFile = site.overviewFile[page.lang] %}{% 
+  if page.path contains overviewFile %} 
+  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}/{{ overviewFile }}.md">{{ site.ViewContentSourceGitHub[page.lang] }}</a></li>{% 
+  else %}{% 
+    assign pageIndex = page.standard | minus: 1 %}
+  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}/{{ site.standardFile[pageIndex][page.lang] }}.md">{{ site.ViewContentSourceGitHub[page.lang] }}</a></li>{% 
+  endif %}{% 
+else %}
+  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}">{{ site.ViewContentSourceGitHub[page.lang] }}</a></li>{% 
+endif %}
+  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.path }}">{{ site.ViewTemplateSourceGitHub[page.lang] }}</a></li>{% 
+assign overviewPath = page.lang | append: "/" | append: site.overviewFile[page.lang] %}{% 
 unless page.url contains overviewPath or page.url contains "compar" %}
-  <li><p><a href="#filter-panel" aria-controls="filter-panel" class="overlay-lnk btn btn-primary" role="button">{{ site.ShowFilters[page.lang] }}</a></li>
-{% endunless %}
+  <li><p><a href="#filter-panel" aria-controls="filter-panel" class="overlay-lnk btn btn-primary" role="button">{{ site.ShowFilters[page.lang] }}</a></li>{% 
+endunless %}
 </ul>

--- a/_includes/page-options.html
+++ b/_includes/page-options.html
@@ -2,7 +2,7 @@
   <li><a href="#feedback-popup" aria-controls="feedback-popup" class="wb-lbx" role="button">{{ site.FeedbackAsk[page.lang] }}</a></li>
 {% if page.path contains "standards-normes" %}{% 
   assign pageIndex = page.standard | minus: 1 %}
-  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}/{{ site.standardFile[pageIndex] }}.md">{{ site.ViewSourceGitHub[page.lang] }}</a></li>
+  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}/{{ site.standardFile[pageIndex][page.lang] }}.md">{{ site.ViewContentSourceGitHub[page.lang] }}</a></li>
 {% else %}
   <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}">{{ site.ViewContentSourceGitHub[page.lang] }}</a></li>
 {% endif %}

--- a/_includes/page-options.html
+++ b/_includes/page-options.html
@@ -1,6 +1,12 @@
 <ul class="list-unstyled{% if include.alignment %} {{ include.alignment }}{% endif %}">
   <li><a href="#feedback-popup" aria-controls="feedback-popup" class="wb-lbx" role="button">{{ site.FeedbackAsk[page.lang] }}</a></li>
-  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.path }}">{{ site.ViewSourceGitHub[page.lang] }}</a></li>
+{% if page.path contains "standards-normes" %}{% 
+  assign pageIndex = page.standard | minus: 1 %}
+  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}/{{ site.standardFile[pageIndex] }}.md">{{ site.ViewSourceGitHub[page.lang] }}</a></li>
+{% else %}
+  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.lang }}">{{ site.ViewContentSourceGitHub[page.lang] }}</a></li>
+{% endif %}
+  <li><a href="https://github.com/{{ site.github_username }}{{ site.baseurl }}/tree/master/{{ page.path }}">{{ site.ViewOutputSourceGitHub[page.lang] }}</a></li>
 {% assign overviewPath = page.lang | append: "/" | append: site.overviewFile[page.lang] %}{% 
 unless page.url contains overviewPath or page.url contains "compar" %}
   <li><p><a href="#filter-panel" aria-controls="filter-panel" class="overlay-lnk btn btn-primary" role="button">{{ site.ShowFilters[page.lang] }}</a></li>


### PR DESCRIPTION
- Replaced "View source" link with "View content source" and "View template source" links to provide quick access to both the source of the page content and the "view" source.
- Fixes #215 