### PR TITLE
Moved Digital Architectural Standards content to the view files

### DIFF
--- a/en/1-design-with-users.md
+++ b/en/1-design-with-users.md
@@ -171,15 +171,6 @@ User needs are constantly evolving which it is why it is important to plan for o
 
 **[TODO: Add/revise checklist items]**
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-design-for-users-first-1} Focus on the needs of users, using agile, iterative and user-centred methods.
-- {: .dpgn-digital-architectural-design-for-users-first-2} Perform user research from the earliest design through to continuous improvements post-launch.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Alpha stage:**
 {: .dpgn-data-ignore}
 
@@ -231,11 +222,6 @@ User needs are constantly evolving which it is why it is important to plan for o
 ### Similar resources
 
 - [2. Do ongoing user research (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/do-ongoing-user-research)
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-design-for-users-first} [3. Design for Users First (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#design-for-users-first)
 
 </section>
 </section>

--- a/en/10-be-good-data-stewards.md
+++ b/en/10-be-good-data-stewards.md
@@ -92,18 +92,6 @@ At every stage of a project, we should measure how well our service is working f
 - Publish metrics externally **(Digital Services Playbook (US))**
 - Use an experimentation tool that supports multivariate testing in production **(Digital Services Playbook (US))**
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-keep-data-organized-1} Decouple Master Data from applications and host within the appropriate system of record.
-- {: .dpgn-digital-architectural-keep-data-organized-2} Make systems of record authoritative central sources.
-{: .dpgn-digital-architectural}
-- {: .dpgn-digital-architectural-keep-data-organized-4} Design data resiliency in accordance with GC policies and standards.
-- {: .dpgn-digital-architectural-keep-data-organized-5} Use Master Data Management to provide a single point of reference for appropriate stakeholders.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Automated Decision Systems:**
 {: .dpgn-data-ignore}
 
@@ -159,11 +147,6 @@ At every stage of a project, we should measure how well our service is working f
 
 - [12. Use data to drive decisions (Digital Services Playbook (US))](https://playbook.cio.gov/#play12)
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-keep-data-organized} [8. Keep Data Organized (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#keep-data-organized)
-
 </section>
 </section>
 
@@ -191,14 +174,6 @@ Measuring performance means continuously improving a service by:
 ### Checklist
 
 **[TODO: Add/revise checklist items]**
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-keep-data-organized-3} Assign data custodians to ensuring data is correct, consistent, and complete.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
 
 **Ensure data is well-structured, intuitive and in a format that is easy to integrate and reuse by others (formerly guideline 10.6):**
 {: .dpgn-data-ignore}
@@ -277,11 +252,6 @@ Measuring performance means continuously improving a service by:
 - [15. Collect performance data (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/collect-performance-data)
 - [13. Measure performance (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-13)
 - [11. Measure performance (Digital Service Standard (AU))](https://www.dta.gov.au/standard/11-measure-performance/)
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-keep-data-organized} [8. Keep Data Organized (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#keep-data-organized)
 
 </section>
 </section>

--- a/en/2-build-in-accessibility-from-start.md
+++ b/en/2-build-in-accessibility-from-start.md
@@ -173,14 +173,6 @@ If users find it difficult to complete the task the first time, they may avoid u
 - provide an accessible method for all users to provide feedback on the service or request additional support at any time **(Digital Service Standard (Ontario))**
 - make sure your staff will be equipped with knowledge of barriers to accessibility and will be trained to assist users with disabilities in completing tasks and accessing information **(Digital Service Standard (Ontario))**
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-design-for-users-first-3} Conform to both accessibility and official languages requirements.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Alpha stage:**
 {: .dpgn-data-ignore}
 
@@ -265,11 +257,6 @@ If users find it difficult to complete the task the first time, they may avoid u
 
 - [7. Make it accessible (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-7)
 - [9. Make it accessible (Digital Service Standard (AU))](https://www.dta.gov.au/standard/9-make-it-accessible/)
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-design-for-users-first} [3. Design for Users First (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#design-for-users-first)
 
 </section>
 </section>

--- a/en/3-collaborate-widely.md
+++ b/en/3-collaborate-widely.md
@@ -73,14 +73,6 @@ To be successful, build a team with:
 - Make sure the team fully understands the service after it's gone live **(Digital Service Standard (UK))**
 - Involve the maintenance team for the service early on in the project **(Digital Service Standard (Ontario))**
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-multidisciplinary-teams-1} Include all skillsets required for delivery, including for requirements, design, development, and operations.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Automated Decision Systems:**
 {: .dpgn-data-ignore}
 
@@ -142,11 +134,6 @@ To be successful, build a team with:
 - [2. Establish the right team (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-2)
 - [7. Bring in experienced teams (Digital Services Playbook (US))](https://playbook.cio.gov/#play7)
 - [2. Have a multidisciplinary team (Digital Service Standard (AU))](https://www.dta.gov.au/standard/2-multidisciplinary-team/)
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams} [4. Deliver with Multidisciplinary Teams (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#deliver-with-multidisciplinary-teams)
 
 </section>
 </section>

--- a/en/4-empower-staff-deliver-better-services.md
+++ b/en/4-empower-staff-deliver-better-services.md
@@ -208,15 +208,6 @@ Every service must have a person that will hold the designate authority to make 
 - The particular data sources and data-capture methods are appropriately identified; a roadmap highlights performance analysis and responsibilities for the identification of actionable data insights.
 - The service can be improved through iteration with the necessary resources and flexibility.
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-multidisciplinary-teams-3} Ensure quality is considered throughout the Software Development Lifecycle.
-- {: .dpgn-digital-architectural-multidisciplinary-teams-4} Encourage and adopt Test Driven Development (TDD) to improve the trust between Business and IT.
-{: .dpgn-standards-hide .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams}
-<!-- markdownlint-enable MD032 -->
-
 </section>
 
 <section class="dpgn-section-guides">
@@ -243,14 +234,6 @@ Every service must have a person that will hold the designate authority to make 
 - [1. Better services rather than new websites. Optimize business processes before designing technological solutions. (Do - Digital Design Playbook (ISED)) (internal to Government of Canada)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#1._Better_services_rather_than_new_websites._Optimize_business_processes_before_designing_technological_solutions.)
 - [6. Assign one leader and hold that person accountable (Digital Services Playbook (US))](https://playbook.cio.gov/#play6)
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-standards-hide .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams} [4. Deliver with Multidisciplinary Teams (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#deliver-with-multidisciplinary-teams)
-{: .dpgn-standards-hide .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 </section>
 </section>
 
@@ -276,14 +259,6 @@ We must empower staff to share power and control over projects. This can involve
 - Have clear objectives, milestones, and defined roles to assist employees as they navigate interactions with users.
 - Allow employees to grow into personal roles, and avoid the limits of hierarchy within team member/manager dynamics.
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-multidisciplinary-teams-2} Work across the entire application lifecycle, from development and test to deployment to operations.
-{: .dpgn-standards-hide .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams}
-<!-- markdownlint-enable MD032 -->
-
 </section>
 
 <section class="dpgn-section-guides">
@@ -307,14 +282,6 @@ We must empower staff to share power and control over projects. This can involve
 ### Similar resources
 
 - [Forbes - 6 ways to empower others to succeed](https://www.forbes.com/sites/lisaquast/2011/02/28/6-ways-to-empower-others-to-succeed/#32a2a275c620)
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-standards-hide .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams} [4. Deliver with Multidisciplinary Teams (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#deliver-with-multidisciplinary-teams)
-{: .dpgn-standards-hide .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
 
 </section>
 </section>

--- a/en/5-work-in-open-by-default.md
+++ b/en/5-work-in-open-by-default.md
@@ -71,16 +71,6 @@ This includes working in the open, sharing any and all data and information prod
 - Ensure that we maintain the rights to all data developed by third parties in a manner that is releasable and reusable at no cost to the public **(Digital Services Playbook (US))**
 - Data and code is shared so that clients can extract/create value. **(General design principles - Digital Design Playbook (ISED))**
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-open-standards-solutions-3} Make source code open and reusable under an appropriate open source software license.
-- {: .dpgn-digital-architectural-open-standards-solutions-4} Expose public data to implement Open Data and Open Information initiatives.
-{: .dpgn-digital-architectural}
-- {: .dpgn-digital-architectural-maximize-reuse-5} Share code publicly when appropriate, and when not, share within the Government of Canada.
-<!-- markdownlint-enable MD032 -->
-
 **Work in the open and make source code open and reusable (formerly guideline 5.5):**
 {: .dpgn-data-ignore}
 
@@ -141,12 +131,6 @@ This includes working in the open, sharing any and all data and information prod
 
 - [Data and code is default to open (General design principles - Digital Design Playbook (ISED)) (internal to Government of Canada)](http://www.gcpedia.gc.ca/wiki/Digital_Design_Playbook)
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-open-standard-solutions} [1. Use Open Standards and Solutions by Default (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#use-open-standards-and-solutions-by-default)
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-maximize-reuse} [2. Maximize Reuse (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#maximize-reuse)
-
 **Work in the open and make source code open and reusable (formerly guideline 5.5):**
 {: .dpgn-data-ignore}
 
@@ -181,14 +165,6 @@ This includes working in the open, sharing any and all data and information prod
 
 **[TODO: Add/revise checklist items]**
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-measurable-accountable-1} Publish a Service Level Agreement for each service.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 </section>
 
 <section class="dpgn-section-guides">
@@ -204,17 +180,6 @@ This includes working in the open, sharing any and all data and information prod
 ### Reusable solutions
 
 **[TODO: Add/revise reusable solutions]**
-
-</section>
-
-<section class="dpgn-section-similar">
-
-### Similar resources
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-measurable-accountable} [7. Design Systems to be Measurable and Accountable (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#design-systems-to-be-measurable-and-accountable)
 
 </section>
 </section>
@@ -243,16 +208,6 @@ Setting performance indicators allows you to continuously improve your service b
 ### Checklist
 
 **[TODO: Add/revise checklist items]**
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-measurable-accountable-2} Make an audit trail available for all transactions to ensure accountability and non-repudiation.
-- {: .dpgn-digital-architectural-measurable-accountable-3} Establish business and IT metrics to enable business outcomes.
-- {: .dpgn-digital-architectural-measurable-accountable-4} Apply oversight and lifecycle management to digital investments through governance.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
 
 **Automated Decision Systems:**
 {: .dpgn-data-ignore}
@@ -328,11 +283,6 @@ Setting performance indicators allows you to continuously improve your service b
 ### Similar resources
 
 - [16. Identify performance indicators (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/identify-performance-indicators)
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-measurable-accountable} [7. Design Systems to be Measurable and Accountable (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#design-systems-to-be-measurable-and-accountable)
 
 </section>
 </section>

--- a/en/6-use-open-standards-solutions.md
+++ b/en/6-use-open-standards-solutions.md
@@ -76,19 +76,6 @@ There are many potential benefits from the greater use of digital services, incl
 - Avoiding lock-in to any proprietary solutions where open source software and/or open standards are available
 - Ensure that software can be deployed on a variety of commodity hardware types
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-open-standards-solutions-1} Use open source standards, solutions, components, and leading practices.
-- {: .dpgn-digital-architectural-open-standards-solutions-2} Enforce this order of preference: open source first, then platform-agnostic COTS, then proprietary COTS, and lastly custom-built.
-- {: .dpgn-digital-architectural-performance-availability-scalability-1} Design for resiliency.
-- {: .dpgn-digital-architectural-performance-availability-scalability-2} Ensure response times meet user needs, and critical services are highly available.
-- {: .dpgn-digital-architectural-performance-availability-scalability-3} Support zero-downtime deployments for planned and unplanned maintenance.
-- {: .dpgn-digital-architectural-performance-availability-scalability-4} Use distributed architectures, assume failure will happen, handle errors gracefully, and monitor actively.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Design, build and test end-to-end digital services (formerly guideline 6.5):**
 {: .dpgn-data-ignore}
 
@@ -180,12 +167,6 @@ There are many potential benefits from the greater use of digital services, incl
 - [9. Use open standards and common platforms (Digital Service Standard (Ontario))](https://www.ontario.ca/page/digital-service-standard#section-9)
 - [7. Use open standards and common platforms (Digital Service Standard (AU))](https://www.dta.gov.au/standard/7-open-standards-and-common-platforms/)
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-open-standards-solutions} [1. Use Open Standards and Solutions by Default (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#use-open-standards-and-solutions-by-default)
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-performance-availability-scalability} [5. Design for Performance, Availability, and Scalability (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#design-for-performance-availability-and-scalability)
-
 **Design, build and test end-to-end digital services (formerly guideline 6.5):**
 {: .dpgn-data-ignore}
 
@@ -229,33 +210,6 @@ Using common, proven government solutions, approaches, and platforms will help t
 - Follow the [Canada.ca Content Style Guide](https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/csc-grc-eng.asp)
 - Static assets are served through a content delivery network **(Digital Services Playbook (US))**
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-maximize-reuse-1} Leverage and reuse existing solutions, components, and processes.
-- {: .dpgn-digital-architectural-maximize-reuse-2} Select enterprise and cluster solutions over department-specific solutions.
-- {: .dpgn-digital-architectural-maximize-reuse-3} Achieve simplification by minimizing duplication of components and adhering to relevant standards.
-- {: .dpgn-digital-architectural-maximize-reuse-4} Inform the GC EARB about departmental investments and innovations.
-- {: .dpgn-digital-architectural-enable-interoperability-4} Run applications in containers.
-- {: .dpgn-digital-architectural-enable-interoperability-5} Leverage enterprise digital exchange components such as the GC Service Bus, Digital Exchange Platform, and the API Store, based on fit-for-use.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
-<section>
-  
-#### Cloud services
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-cloud-first-1} Enforce this order of preference: Software as a Service (SaaS) first, then Platform as a Service (PaaS), and lastly Infrastructure as a Service (IaaS).
-- {: .dpgn-digital-architectural-cloud-first-2} Enforce this order of preference: Public cloud first, then Hybrid cloud, then Private cloud, and lastly non-cloud (on-premises) solutions.
-- {: .dpgn-digital-architectural-cloud-first-3} Design for cloud mobility and develop an exit strategy to avoid vendor lock-in.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Government of Canada Cloud Adoption Strategy:**
 {: .dpgn-data-ignore}
 
@@ -265,8 +219,6 @@ Using common, proven government solutions, approaches, and platforms will help t
 - To ensure, to the greatest extent possible, the GC’s continuous access to sensitive data, departments and agencies must comply with the [Direction for Electronic Data Residency](https://www.canada.ca/en/treasury-board-secretariat/services/information-technology/policy-implementation-notices/direction-electronic-data-residency.html).
 - To ensure business continuity and to manage risks, departments and agencies will develop an appropriate exit strategy before using cloud services.
 - Departments and agencies should consider portability and interoperability of services when designing cloud-based solutions.
-
-</section>
 
 </section>
 
@@ -316,13 +268,6 @@ Using common, proven government solutions, approaches, and platforms will help t
 - [1. Comply with Government of Canada acts, policies, standards and directives (Plan - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Plan#1._Comply_with_Government_of_Canada_acts.2C_policies.2C_standards_and_directives)
 - [2. Reuse, improve and share technological solutions where appropriate (Do - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#2._Reuse.2C_improve_and_share_technological_solutions_where_appropriate)
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-maximize-reuse} [2. Maximize Reuse (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#maximize-reuse)
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-enable-interoperability} [6. Enable Interoperability (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#enable-interoperability)
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-cloud-first} [9. Use Cloud First (Digital Architectural Standards Principles (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#use-cloud-first)
-
 **Cloud first (formerly guideline 6.6):**
 {: .dpgn-data-ignore}
 
@@ -351,16 +296,6 @@ Application Program Interfaces (APIs) are a means by which business functionalit
 
 **[TODO: Add/revise checklist items]**
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-enable-interoperability-1} Expose all functionality as services.
-- {: .dpgn-digital-architectural-enable-interoperability-2} Use microservices built around business capabilities. Scope each service to a single purpose.
-- {: .dpgn-digital-architectural-enable-interoperability-3} Run each service in its own process and have it communicate with other services through a well-defined interface, such as an HTTPS-based application programming interface (API).
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 - Build services that are API-centric services, which execute most, if not all, functionality through API calls (e.g., connecting frontend to backend through an API)
 - Plan out API access from the beginning, designing services to be able to safely and securely expose functionality to other systems and the public.
 - Design APIs to be compete but also minimal, ensuring the expected functionality is provided but with as few public members per class and as few classes as possible. This makes it easier to understand, remember, debug and change the API.
@@ -387,17 +322,6 @@ Application Program Interfaces (APIs) are a means by which business functionalit
 ### Reusable solutions
 
 **[TODO: Add/revise reusable solutions]**
-
-</section>
-
-<section class="dpgn-section-similar">
-
-### Similar resources
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-enable-interoperability} [6. Enable Interoperability (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#enable-interoperability)
 
 </section>
 </section>

--- a/en/9-address-security-privacy-risks.md
+++ b/en/9-address-security-privacy-risks.md
@@ -66,14 +66,6 @@ Assessing cyber risks cannot be done in isolation. It must be assessed while con
 * Document the process for identifying, understanding new or ongoing security and privacy threats and the process for managing them
 * Establish a cycle of re-evaluation to ensure what you’re protecting is actually what you need to protect and make improvements based on lessons learned.
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-* {: .dpgn-digital-architectural-security-privacy-4} Balance user and business needs with proportionate security measures.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 </section>
 
 <section class="dpgn-section-guides">
@@ -101,11 +93,6 @@ Assessing cyber risks cannot be done in isolation. It must be assessed while con
 * [Managing Risk through Digital Trust (CSO)](https://www.csoonline.com/article/3200753/security/managing-risk-through-digital-trust.html)
 * [Privacy (Digital Service Standards (AU))](https://www.dta.gov.au/standard/design-guides/privacy/)
 * [Secure services (Digital Service Standards (AU))](https://www.dta.gov.au/standard/design-guides/secure-services/)
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-* {: .dpgn-digital-architectural .dpgn-digital-architectural-security-privacy} [10. Security and Privacy by Design (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#security-and-privacy-by-design)
 
 </section>
 </section>
@@ -271,16 +258,6 @@ Canadians want to have confidence that government digital services are designed 
 * Ensure your service has properly documented event management processes, in the event of a data breach or compromise of the integrity of your systems.
 * Establish terms of services to ensure users understand how their data will be used and how it will be accessed
 
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-* {: .dpgn-digital-architectural-security-privacy-1} Implement security across all architectural layers.
-* {: .dpgn-digital-architectural-security-privacy-2} Categorize data properly to determine appropriate safeguards.
-* {: .dpgn-digital-architectural-security-privacy-3} Perform a privacy impact assessment (PIA) when personal information is involved.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Automated Decision Systems:**
 {: .dpgn-data-ignore}
 
@@ -322,11 +299,6 @@ Canadians want to have confidence that government digital services are designed 
 * [7. Understand security and privacy issues (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/understand-security-and-privacy-issues)
 * [11. Manage security and privacy through reusable processes (Digital Services Playbook (US))](https://playbook.cio.gov/#play11)
 * [5. Make it secure (Digital Service Standard (AU))](https://www.dta.gov.au/standard/5-make-it-secure/)
-
-**Digital Architectural Standards (GC):**
-{: .dpgn-data-ignore}
-
-* {: .dpgn-digital-architectural .dpgn-digital-architectural-security-privacy} [10. Security and Privacy by Design (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#security-and-privacy-by-design)
 
 </section>
 </section>

--- a/fr/1-concevoir-avec-utilisateurs.md
+++ b/fr/1-concevoir-avec-utilisateurs.md
@@ -171,15 +171,6 @@ Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est import
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-design-for-users-first-1} Miser sur les besoins des utilisateurs; se servir de méthodes agiles, itératives et axées sur l’utilisateur.
-- {: .dpgn-digital-architectural-design-for-users-first-2} Mener des recherches sur les utilisateurs à partir des toutes premières conceptions, jusqu’aux améliorations ayant été apportées après le lancement.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Stage alpha :**
 {: .dpgn-data-ignore}
 
@@ -231,11 +222,6 @@ Les besoins des utilisateurs évoluent constamment, c'est pourquoi il est import
 ### Ressources similaires
 
 - [2. Do ongoing user research (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/do-ongoing-user-research)
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-design-for-users-first} [3. Concevoir pour les utilisateurs d’abord (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#concevoir-pour-les-utilisateurs-dabord)
 
 </section>
 </section>

--- a/fr/10-etre-bons-utilisateurs-donnees.md
+++ b/fr/10-etre-bons-utilisateurs-donnees.md
@@ -92,18 +92,6 @@ At every stage of a project, we should measure how well our service is working f
 - Publish metrics externally **(Digital Services Playbook (US))**
 - Use an experimentation tool that supports multivariate testing in production **(Digital Services Playbook (US))**
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-keep-data-organized-1} Dissocier les données de base des applications et de l’hôte au sein d’un système d’enregistrement approprié.
-- {: .dpgn-digital-architectural-keep-data-organized-2} Veiller à ce que les systèmes d’enregistrement des sources centrales fassent autorité.
-{: .dpgn-digital-architectural}
-- {: .dpgn-digital-architectural-keep-data-organized-4} Concevoir la résilience des données conformément aux politiques et normes du GC.
-- {: .dpgn-digital-architectural-keep-data-organized-5} Se servir de la gestion des données de base pour fournir un point de référence unique à l’intention des intervenants pertinents.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Automated Decision Systems:**
 {: .dpgn-data-ignore}
 
@@ -159,11 +147,6 @@ At every stage of a project, we should measure how well our service is working f
 
 - [12. Use data to drive decisions (Digital Services Playbook (US))](https://playbook.cio.gov/#play12)
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-keep-data-organized} [8. Veiller à l’organisation des données (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#veiller--lorganisation-des-donnes)
-
 </section>
 </section>
 
@@ -191,14 +174,6 @@ La mesure du rendement permet d’améliorer en continu un service en :
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-keep-data-organized-3} Assigner des gardiens des données afin de veiller à ce que les données soient précises, uniformes et intégrales.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
 
 **Assurez-vous que les données sont bien structurées, intuitives et dans un format facile à intégrer et réutiliser par d'autres (anciennement ligne directrice 10.6):**
 {: .dpgn-data-ignore}
@@ -278,11 +253,6 @@ La mesure du rendement permet d’améliorer en continu un service en :
 - [15. Collect performance data (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/collect-performance-data)
 - [13. Mesurer le rendement (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-13)
 - [11. Measure performance (Digital Service Standard (AU))](https://www.dta.gov.au/standard/11-measure-performance/)
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-keep-data-organized} [8. Veiller à l’organisation des données (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#veiller--lorganisation-des-donnes)
 
 </section>
 </section>

--- a/fr/2-integrer-accessibilite-des-depart.md
+++ b/fr/2-integrer-accessibilite-des-depart.md
@@ -174,14 +174,6 @@ Si les utilisateurs ont des difficultés à atteindre leur objectif du premier c
 - fournir une méthode accessible permettant à tous les utilisateurs de faire des commentaires sur le service ou de demander du soutien supplémentaire à tout moment **(Normes des services numériques (Ontario))**
 - démontrer de quelle manière votre personnel connaîtra les obstacles à l’accessibilité et sera formé pour aider les utilisateurs handicapés à faire ce qu’ils veulent faire et à accéder à l’information **(Normes des services numériques (Ontario))**
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-design-for-users-first-3} Se conformer aux exigences en matière d’accessibilité et de langues officielles.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Stage alpha :**
 {: .dpgn-data-ignore}
 
@@ -266,12 +258,6 @@ Si les utilisateurs ont des difficultés à atteindre leur objectif du premier c
 
 - [7. Rendre le service accessible (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-7)
 - [9. Make it accessible (Digital Service Standard (AU))](https://www.dta.gov.au/standard/9-make-it-accessible/)
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-design-for-users-first} [3. Concevoir pour les utilisateurs d’abord
- (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#concevoir-pour-les-utilisateurs-dabord)
 
 </section>
 </section>

--- a/fr/3-collaborer-largement.md
+++ b/fr/3-collaborer-largement.md
@@ -73,14 +73,6 @@ Pour assurer une réussite optimale, constituez une équipe dotée :
 - Make sure the team fully understands the service after it's gone live **(Digital Service Standard (UK))**
 - faites participer l’équipe de maintenance du service aux premières étapes du projet **(Normes des services numériques (Ontario))**
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-multidisciplinary-teams-1} Tenir compte de toutes les compétences nécessaires à la prestation, y compris celles qui ont trait aux exigences, à la conception, à l’élaboration et aux opérations.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Automated Decision Systems:**
 {: .dpgn-data-ignore}
 
@@ -142,11 +134,6 @@ Pour assurer une réussite optimale, constituez une équipe dotée :
 - [2. Former une équipe adaptée (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-2)
 - [7. Bring in experienced teams (Digital Services Playbook (US))](https://playbook.cio.gov/#play7)
 - [2. Have a multidisciplinary team (Digital Service Standard (AU))](https://www.dta.gov.au/standard/2-multidisciplinary-team/)
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams} [4. Assurer la prestation à l’aide d’équipes multidisciplinaires (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#assurer-la-prestation--laide-déquipes-multidisciplinaires)
 
 </section>
 </section>

--- a/fr/4-permettre-personnel-offrir-meilleurs-services.md
+++ b/fr/4-permettre-personnel-offrir-meilleurs-services.md
@@ -208,15 +208,6 @@ Every service must have a person that will hold the designate authority to make 
 - The particular data sources and data-capture methods are appropriately identified; a roadmap highlights performance analysis and responsibilities for the identification of actionable data insights.
 - The service can be improved through iteration with the necessary resources and flexibility.
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-multidisciplinary-teams-3} Veiller à ce que l’on tienne compte de la qualité tout au long du cycle de vie d’élaboration du logiciel.
-- {: .dpgn-digital-architectural-multidisciplinary-teams-4} Encourager et adopter le développement piloté par les tests (DPT) pour améliorer la confiance qui règne entre les entreprises et la TI.
-{: .dpgn-standards-hide .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams}
-<!-- markdownlint-enable MD032 -->
-
 </section>
 
 <section class="dpgn-section-guides">
@@ -242,14 +233,6 @@ Every service must have a person that will hold the designate authority to make 
 - [5. Structure budgets and contracts to support delivery (Digital Services Playbook (US))](https://playbook.cio.gov/#play5)
 - [1. Better services rather than new websites. Optimize business processes before designing technological solutions. (Do - Digital Design Playbook (ISED)) (internal to Government of Canada)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#1._Better_services_rather_than_new_websites._Optimize_business_processes_before_designing_technological_solutions.)
 - [6. Assign one leader and hold that person accountable (Digital Services Playbook (US))](https://playbook.cio.gov/#play6)
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-standards-hide .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams} [4. Assurer la prestation à l’aide d’équipes multidisciplinaires (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#assurer-la-prestation--laide-déquipes-multidisciplinaires)
-{: .dpgn-standards-hide .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
 
 </section>
 </section>
@@ -278,14 +261,6 @@ We must empower staff to share power and control over projects. This can involve
 - Have clear objectives, milestones, and defined roles to assist employees as they navigate interactions with users.
 - Allow employees to grow into personal roles, and avoid the limits of hierarchy within team member/manager dynamics.
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-multidisciplinary-teams-2} Travailler de façon à couvrir le cycle de vie tout entier de l’application, de son élaboration à sa mise à l’essai, et du déploiement aux opérations.
-{: .dpgn-standards-hide .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams}
-<!-- markdownlint-enable MD032 -->
-
 </section>
 
 <section class="dpgn-section-guides">
@@ -301,20 +276,6 @@ We must empower staff to share power and control over projects. This can involve
 ### Solutions réutilisables
 
 **[TODO: Ajouter / réviser les solutions réutilisables]**
-
-</section>
-
-<section class="dpgn-section-similar">
-
-### Ressources similaires
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-standards-hide .dpgn-digital-architectural .dpgn-digital-architectural-multidisciplinary-teams} [4. Assurer la prestation à l’aide d’équipes multidisciplinaires (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#assurer-la-prestation--laide-déquipes-multidisciplinaires)
-{: .dpgn-standards-hide .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
 
 </section>
 </section>

--- a/fr/5-travailler-ouvertement-par-defaut.md
+++ b/fr/5-travailler-ouvertement-par-defaut.md
@@ -71,16 +71,6 @@ Cela implique de travailler ouvertement, de partager toutes les données et info
 - Ensure that we maintain the rights to all data developed by third parties in a manner that is releasable and reusable at no cost to the public **(Digital Services Playbook (US))**
 - Data and code is shared so that clients can extract/create value. **(General design principles - Digital Design Playbook (ISED))**
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-open-standards-solutions-3} Rendre le code source ouvert et réutilisable en vertu d’une licence de logiciel à source ouverte.
-- {: .dpgn-digital-architectural-open-standards-solutions-4} Exposer les données publiques afin de procéder à la mise en œuvre d’initiatives sur les données ouvertes et l’information ouverte.
-{: .dpgn-digital-architectural}
-- {: .dpgn-digital-architectural-maximize-reuse-5} Partager le code publiquement lorsqu’il est approprié de le faire et, lorsqu’il n’est pas pratique de le faire, le partager au sein du gouvernement du Canada.
-<!-- markdownlint-enable MD032 -->
-
 **Travailler ouvertement et rendre le code source ouvert et réutilisable (anciennement ligne directrice 5.5) :**
 {: .dpgn-data-ignore}
 
@@ -141,12 +131,6 @@ Cela implique de travailler ouvertement, de partager toutes les données et info
 
 - [Data and code is default to open (General design principles - Digital Design Playbook (ISED)) (internal to Government of Canada)](http://www.gcpedia.gc.ca/wiki/Digital_Design_Playbook)
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-open-standard-solutions} [1. Se servir de normes et de solutions ouvertes par défaut (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#se-servir-de-normes-et-de-solutions-ouvertes-par-dfaut)
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-maximize-reuse} [2. Maximiser la réutilisation (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#maximiser-la-rutilisation)
-
 **Travailler ouvertement et rendre le code source ouvert et réutilisable (anciennement ligne directrice 5.5)&#160;:**
 {: .dpgn-data-ignore}
 
@@ -181,14 +165,6 @@ Cela implique de travailler ouvertement, de partager toutes les données et info
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-measurable-accountable-1} Publier un accord sur les niveaux de service pour chaque service.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 </section>
 
 <section class="dpgn-section-guides">
@@ -204,17 +180,6 @@ Cela implique de travailler ouvertement, de partager toutes les données et info
 ### Solutions réutilisables
 
 **[TODO: Ajouter / réviser les solutions réutilisables]**
-
-</section>
-
-<section class="dpgn-section-similar">
-
-### Ressources similaires
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-measurable-accountable} [7. Concevoir des systèmes mesurables et responsables (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#concevoir-des-systmes-mesurables-et-responsables)
 
 </section>
 </section>
@@ -243,16 +208,6 @@ Setting performance indicators allows you to continuously improve your service b
 ### Liste de contrôle
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-measurable-accountable-2} Veiller à ce qu’une piste d’audit soit disponible pour toutes les transactions, afin d’assurer la responsabilisation et la non-répudiation.
-- {: .dpgn-digital-architectural-measurable-accountable-3} Établir des paramètres opérationnels et de la TI afin de faciliter l’atteinte de résultats opérationnels.
-- {: .dpgn-digital-architectural-measurable-accountable-4} Appliquer des principes de surveillance et de gestion du cycle de vie aux investissements numériques par l’entremise de la gouvernance.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
 
 **Automated Decision Systems:**
 {: .dpgn-data-ignore}
@@ -328,11 +283,6 @@ Setting performance indicators allows you to continuously improve your service b
 ### Ressources similaires
 
 - [16. Identify performance indicators (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/identify-performance-indicators)
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architecutral .dpgn-digital-architectural-measurable-accountable} [7. Concevoir des systèmes mesurables et responsables (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#concevoir-des-systmes-mesurables-et-responsables)
 
 </section>
 </section>

--- a/fr/6-utiliser-normes-solutions-ouvertes.md
+++ b/fr/6-utiliser-normes-solutions-ouvertes.md
@@ -76,19 +76,6 @@ There are many potential benefits from the greater use of digital services, incl
 - Éviter le verrouillage à toutes les solutions propriétaires où des logiciels libres et / ou des normes ouvertes sont disponibles
 - Assurez-vous que le logiciel peut être déployé sur une variété de types de matériel de base
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-open-standards-solutions-1} Se servir de normes, solutions, composantes et pratiques de pointe en matière de source ouverte.
-- {: .dpgn-digital-architectural-open-standards-solutions-2} Préconiser cet ordre de préférences : source ouverte d’abord, puis les logiciels disponibles sur le marché qui sont indifférents à la plateforme, puis les logiciels disponibles sur le marché exclusifs, puis en dernier lieu, les logiciels conçus sur mesure.
-- {: .dpgn-digital-architectural-performance-availability-scalability-1} Concevoir à des fins de résilience.
-- {: .dpgn-digital-architectural-performance-availability-scalability-2} Veiller à ce que les temps de réponse répondent aux besoins des utilisateurs, et que les services critiques soient grandement disponibles.
-- {: .dpgn-digital-architectural-performance-availability-scalability-3} Appuyer les déploiements sans temps morts, dans les cas de maintenance planifiée et non planifiée.
-- {: .dpgn-digital-architectural-performance-availability-scalability-4} Se servir d’architectures distribuées, en présumant que des échecs se produiront, traiter des erreurs avec dignité, et surveiller activement.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Concevoir, créer et tester des services numériques de bout en bout (anciennement ligne directrice 6.5) :**
 {: .dpgn-data-ignore}
 
@@ -180,12 +167,6 @@ There are many potential benefits from the greater use of digital services, incl
 - [9. Utiliser des normes ouvertes et des plateformes communes (Normes des services numériques (Ontario))](https://www.ontario.ca/fr/page/norme-des-services-numeriques#section-9)
 - [7. Use open standards and common platforms (Digital Service Standard (AU))](https://www.dta.gov.au/standard/7-open-standards-and-common-platforms/)
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-open-standards-solutions} [1. Se servir de normes et de solutions ouvertes par défaut (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#se-servir-de-normes-et-de-solutions-ouvertes-par-dfaut)
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-performance-availability-scalability} [5. Concevoir à des fins de rendement, de disponibilité et d’échelonnabilité (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#concevoir--des-fins-de-rendement-de-disponibilit-et-dchelonnabilit)
-
 **Concevoir, créer et tester des services numériques de bout en bout (anciennement ligne directrice 6.5) :**
 {: .dpgn-data-ignore}
 
@@ -229,33 +210,6 @@ Using common, proven government solutions, approaches, and platforms will help t
 - Follow the [Canada.ca Content Style Guide](https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/csc-grc-eng.asp)
 - Static assets are served through a content delivery network **(Digital Services Playbook (US))**
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-maximize-reuse-1} Tirer parti et réutiliser les solutions, composantes et processus qui existent déjà.
-- {: .dpgn-digital-architectural-maximize-reuse-2} Sélectionner des solutions intégrées et regroupées avant d’opter pour des solutions spécifiques à un ministère.
-- {: .dpgn-digital-architectural-maximize-reuse-3} Réaliser la simplification en minimisant le dédoublement des composantes et en s’en tenant aux normes pertinentes.
-- {: .dpgn-digital-architectural-maximize-reuse-4} Informer le CEAI GC des investissements et des innovations ministériels.
-- {: .dpgn-digital-architectural-enable-interoperability-4} Faire rouler les applications en conteneurs.
-- {: .dpgn-digital-architectural-enable-interoperability-5} Tirer parti des composantes intégrées d’échange numérique comme le Bus de service du GC, la plateforme d’échange numérique, et le magasin IPA, conçu à des fins d’utilisation sur mesure.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
-<section>
-
-#### Services d’informatique en nuage
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-cloud-first-1} Préconiser cet ordre de préférences : Logiciel comme service (SaaS) d’abord, puis Plateforme comme service (PaaS), et en dernier lieu, l’Infrastructure comme service (IaaS).
-- {: .dpgn-digital-architectural-cloud-first-2} Préconiser cet ordre de préférences : Le nuage public d’abord, ensuite, le nuage hybride, puis le nuage privé et, en dernier lieu, les solutions non nuagiques (sur site).
-- {: .dpgn-digital-architectural-cloud-first-3} Concevoir en vue d’une mobilité nuagique, et élaborer une stratégie de sortie afin d’éviter l’enfermement propriétaire.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 **Stratégie d’adoption de l’informatique en nuage du gouvernement du Canada :**
 {: .dpgn-data-ignore}
 
@@ -265,8 +219,6 @@ Using common, proven government solutions, approaches, and platforms will help t
 - Pour garantir, dans la mesure du possible, l’accès continu du GC aux données de nature délicate, les ministères et organismes doivent se conformer à l’[Orientation relative à la résidence des données électroniques](https://www.canada.ca/fr/secretariat-conseil-tresor/services/technologie-information/avis-mise-oeuvre-politique/orientation-relative-residence-donnees-electroniques.html).
 - Pour assurer la continuité des activités et gérer les risques, les ministères et organismes élaboreront une stratégie de retrait appropriée avant d’utiliser les services d’informatique en nuage.
 - Les ministères et organismes devraient tenir compte de la transférabilité et de l’interopérabilité des services au moment d’élaborer des solutions d’informatique en nuage.
-
-</section>
 
 </section>
 
@@ -316,13 +268,6 @@ Using common, proven government solutions, approaches, and platforms will help t
 - [1. Comply with Government of Canada acts, policies, standards and directives (Plan - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Plan#1._Comply_with_Government_of_Canada_acts.2C_policies.2C_standards_and_directives)
 - [2. Reuse, improve and share technological solutions where appropriate (Do - Digital Design Playbook (ISED)) (internal to GC only)](http://www.gcpedia.gc.ca/wiki/DDPlayBook_Do#2._Reuse.2C_improve_and_share_technological_solutions_where_appropriate)
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-maximize-reuse} [2. Maximiser la réutilisation (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#maximiser-la-rutilisation)
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-enable-interoperability} [6. Permettre l’interopérabilité (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#permettre-linteroprabilit)
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-cloud-first} [9. Se servir du nuage d’abord (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/fr/ceai-gc.html#se-servir-du-nuage-dabord)
-
 **Nuage d'abord (anciennement ligne directrice 6.6) :**
 {: .dpgn-data-ignore}
 
@@ -351,16 +296,6 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 
 **\[TODO: Ajouter / modifier les éléments de la liste de contrôle\]**
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-- {: .dpgn-digital-architectural-enable-interoperability-1} Exposer toutes les fonctionnalités en tant que services.
-- {: .dpgn-digital-architectural-enable-interoperability-2} Se servir de microservices ayant été conçus autour des capacités opérationnelles. Concevoir chaque servir à une fin particulière.
-- {: .dpgn-digital-architectural-enable-interoperability-3} Exploiter chaque service selon son propre processus, et veiller à ce qu’il communique avec les autres services par l’entremise d’une interface bien définie, comme une Interface de programmation d’applications (IPA) axée sur un protocole HTTPS.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 - Build services that are API-centric services, which execute most, if not all, functionality through API calls (e.g., connecting frontend to backend through an API)
 - Plan out API access from the beginning, designing services to be able to safely and securely expose functionality to other systems and the public.
 - Design APIs to be compete but also minimal, ensuring the expected functionality is provided but with as few public members per class and as few classes as possible. This makes it easier to understand, remember, debug and change the API.
@@ -387,17 +322,6 @@ Les interfaces de programme d'application (API) sont un moyen par lequel les fon
 ### Solutions réutilisables
 
 **[TODO: Ajouter / réviser les solutions réutilisables]**
-
-</section>
-
-<section class="dpgn-section-similar">
-
-### Ressources similaires
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-- {: .dpgn-digital-architectural .dpgn-digital-architectural-enable-interoperability} [6. Permettre l’interopérabilité (Normes architecturales sur le numérique (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#permettre-linteroprabilit)
 
 </section>
 </section>

--- a/fr/9-gerer-risques-matiere-securite-protection-renseignements-personnels.md
+++ b/fr/9-gerer-risques-matiere-securite-protection-renseignements-personnels.md
@@ -66,14 +66,6 @@ Assessing cyber risks cannot be done in isolation. It must be assessed while con
 * Document the process for identifying, understanding new or ongoing security and privacy threats and the process for managing them
 * Establish a cycle of re-evaluation to ensure what you’re protecting is actually what you need to protect and make improvements based on lessons learned.
 
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-<!-- markdownlint-disable MD032 -->
-* {: .dpgn-digital-architectural-security-privacy-4} Équilibrer les besoins des utilisateurs aux besoins organisationnels en se dotant de mesures de sécurité proportionnelles.
-{: .dpgn-digital-architectural}
-<!-- markdownlint-enable MD032 -->
-
 </section>
 
 <section class="dpgn-section-guides">
@@ -101,11 +93,6 @@ Assessing cyber risks cannot be done in isolation. It must be assessed while con
 * [Managing Risk through Digital Trust (CSO)](https://www.csoonline.com/article/3200753/security/managing-risk-through-digital-trust.html)
 * [Privacy (Digital Service Standards (AU))](https://www.dta.gov.au/standard/design-guides/privacy/)
 * [Secure services (Digital Service Standards (AU))](https://www.dta.gov.au/standard/design-guides/secure-services/)
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-* {: .dpgn-digital-architectural .dpgn-digital-architectural-security-privacy} [10. Concevoir en vue de la sécurité et de la protection des renseignements personnels (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#concevoir-en-vue-de-la-scurit-et-de-la-protection-des-renseignements-personnels)
 
 </section>
 </section>
@@ -322,11 +309,6 @@ Canadians want to have confidence that government digital services are designed 
 * [7. Understand security and privacy issues (Digital Service Standard (UK))](https://www.gov.uk/service-manual/service-standard/understand-security-and-privacy-issues)
 * [11. Manage security and privacy through reusable processes (Digital Services Playbook (US))](https://playbook.cio.gov/#play11)
 * [5. Make it secure (Digital Service Standard (AU))](https://www.dta.gov.au/standard/5-make-it-secure/)
-
-**Normes architecturales sur le numérique (GC)&#160;:**
-{: .dpgn-data-ignore}
-
-* {: .dpgn-digital-architectural .dpgn-digital-architectural-security-privacy} [10. Concevoir en vue de la sécurité et de la protection des renseignements personnels (Digital Architectural Standards (GC))](https://canada-ca.github.io/digital-playbook-guide-numerique/views-vues/gc-earb-ceai/en/gc-earb.html#concevoir-en-vue-de-la-scurit-et-de-la-protection-des-renseignements-personnels)
 
 </section>
 </section>

--- a/views-vues/gc-earb-ceai/en/gc-earb.md
+++ b/views-vues/gc-earb-ceai/en/gc-earb.md
@@ -7,90 +7,86 @@ altLangPage: ceai-gc
 collectionDirectory: views-vues/gc-earb-ceai
 ---
 
-The Government of Canada Digital Architectural Standards shall be applied to digital projects and initiatives in order to successfully align with the Government of Canada digital direction. The Government of Canada Enterprise Architecture Review Board (GC EARB) will use these standards to evaluate digital investments and solutions. The Digital Architectural Standards build upon the Government of Canada Digital Standards, focusing on best practices for architectural and design planning.
+The Government of Canada Architectural Standards shall be applied to digital projects and initiatives in order to successfully align with the Government of Canada digital direction. The Government of Canada Enterprise Architecture Review Board (GC EARB) will use these standards to evaluate digital investments and solutions to ensure the GC acts as a single enterprise by validating, recommending and approving technology solutions and to ensure departmental alignment with enterprise-wide IT standards, security, and strategic direction. The Architectural Standards build upon the Government of Canada Digital Standards, focusing on best practices for architectural and design planning.
+{: .dpgn-data-ignore}
 
 This page provides personalized guidance for how projects can meet the Government of Canada Digital Architectural Standards required by the Government of Canada Enterprise Architecture Review Board (GC EARB).
+{: .dpgn-data-ignore}
 
 <!-- markdownlint-disable MD032 -->
 - TOC
-{:toc .lst-spcd}
+{:toc .lst-spcd .dpgn-data-ignore}
 <!-- markdownlint-enable MD032 -->
 
 <section>
 
-## 1. Use Open Standards and Solutions by Default
+<!-- markdownlint-disable MD022 -->
+## 1. Business Architecture
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-open-standards-solutions-1,dpgn-digital-architectural-open-standards-solutions-2,dpgn-digital-architectural-open-standards-solutions-3,dpgn-digital-architectural-open-standards-solutions-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-open-standards-solutions-1,dpgn-digital-architectural-open-standards-solutions-2,dpgn-digital-architectural-open-standards-solutions-3,dpgn-digital-architectural-open-standards-solutions-4" guidelineSectionsOrder="checklist" %}
+<section>
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-open-standards-solutions" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+<!-- markdownlint-disable MD022 -->
+### Align to the GC Business Capability model
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Define program services as business capabilities to establish a common vocabulary between business, development, and operation
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Identify capabilities that are common to the GC enterprise and can be shared and reused
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Model business processes using Unified Modelling language to identify common enterprise processes
+{: .dpgn-digital-architectural-align-gc-business-capability-model .dpgn-business-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-align-gc-business-capability-model" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
 </section>
 
 <section>
 
-## 2. Maximize Reuse
+<!-- markdownlint-disable MD022 -->
+### Design for Users First and Deliver with Multidisciplinary Teams
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-maximize-reuse-1,dpgn-digital-architectural-maximize-reuse-2,dpgn-digital-architectural-maximize-reuse-3,dpgn-digital-architectural-maximize-reuse-4,dpgn-digital-architectural-maximize-reuse-5" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-maximize-reuse-1,dpgn-digital-architectural-maximize-reuse-2,dpgn-digital-architectural-maximize-reuse-3,dpgn-digital-architectural-maximize-reuse-4,dpgn-digital-architectural-maximize-reuse-5" guidelineSectionsOrder="checklist" %}
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-1-2 .dpgn-checklist} Focus on the needs of users, using agile, iterative, and user-centred methods
+- {: .dpgn-guideline-2-2 .dpgn-checklist} Conform to both accessibility and official languages requirements
+- {: .dpgn-guideline-3-1 .dpgn-checklist} Include all skillsets required for delivery, including for requirements, design, development, and operations
+- {: .dpgn-guideline-4-4 .dpgn-checklist} Work across the entire application lifecycle, from development and testing to deployment and operations
+- {: .dpgn-guideline-4-3 .dpgn-checklist} Ensure quality is considered throughout the Software Development Lifecycle
+- {: .dpgn-guideline-4-3 .dpgn-checklist} Encourage and adopt Test Driven Development (TDD) to improve the trust between Business and IT
+{: .dpgn-digital-architectural-design-for-users-first .dpgn-digital-architectural-multidisciplinary-teams .dpgn-business-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-maximize-reuse" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-design-for-users-first,dpgn-digital-architectural-multidisciplinary-teams" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
+</section>
 </section>
 
 <section>
 
-## 3. Design for Users First
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-design-for-users-first-1,dpgn-digital-architectural-design-for-users-first-2,dpgn-digital-architectural-design-for-users-first-3" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-design-for-users-first-1,dpgn-digital-architectural-design-for-users-first-2,dpgn-digital-architectural-design-for-users-first-3" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-design-for-users-first" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
+<!-- markdownlint-disable MD022 -->
+## 2. Information Architecture
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
 <section>
 
-## 4. Deliver with Multidisciplinary Teams
+<!-- markdownlint-disable MD022 -->
+### Keep Data Organized
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-multidisciplinary-teams-1,dpgn-digital-architectural-multidisciplinary-teams-2,dpgn-digital-architectural-multidisciplinary-teams-3,dpgn-digital-architectural-multidisciplinary-teams-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-multidisciplinary-teams-1,dpgn-digital-architectural-multidisciplinary-teams-2,dpgn-digital-architectural-multidisciplinary-teams-3,dpgn-digital-architectural-multidisciplinary-teams-4" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-multidisciplinary-teams" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
-
-<section>
-
-## 5. Design for Performance, Availability, and Scalability
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-performance-availability-scalability-1,dpgn-digital-architectural-performance-availability-scalability-2,dpgn-digital-architectural-performance-availability-scalability-3,dpgn-digital-architectural-performance-availability-scalability-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-performance-availability-scalability-1,dpgn-digital-architectural-performance-availability-scalability-2,dpgn-digital-architectural-performance-availability-scalability-3,dpgn-digital-architectural-performance-availability-scalability-4" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-performance-availability-scalability" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
-
-<section>
-
-## 6. Enable Interoperability
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-enable-interoperability-1,dpgn-digital-architectural-enable-interoperability-2,dpgn-digital-architectural-enable-interoperability-3,dpgn-digital-architectural-enable-interoperability-4,dpgn-digital-architectural-enable-interoperability-5" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-enable-interoperability-1,dpgn-digital-architectural-enable-interoperability-2,dpgn-digital-architectural-enable-interoperability-3,dpgn-digital-architectural-enable-interoperability-4,dpgn-digital-architectural-enable-interoperability-5" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-enable-interoperability" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
-
-<section>
-
-## 7. Design Systems to be Measurable and Accountable
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-measurable-accountable-1,dpgn-digital-architectural-measurable-accountable-2,dpgn-digital-architectural-measurable-accountable-3,dpgn-digital-architectural-measurable-accountable-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-measurable-accountable-1,dpgn-digital-architectural-measurable-accountable-2,dpgn-digital-architectural-measurable-accountable-3,dpgn-digital-architectural-measurable-accountable-4" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-measurable-accountable" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
-
-<section>
-
-## 8. Keep Data Organized
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-keep-data-organized-1,dpgn-digital-architectural-keep-data-organized-2,dpgn-digital-architectural-keep-data-organized-3,dpgn-digital-architectural-keep-data-organized-4,dpgn-digital-architectural-keep-data-organized-5" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-keep-data-organized-1,dpgn-digital-architectural-keep-data-organized-2,dpgn-digital-architectural-keep-data-organized-3,dpgn-digital-architectural-keep-data-organized-4,dpgn-digital-architectural-keep-data-organized-5" guidelineSectionsOrder="checklist" %}
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-10-2 .dpgn-checklist} Decouple Master Data from applications and host within the appropriate system of record 
+- {: .dpgn-guideline-10-2 .dpgn-checklist} Make systems of record authoritative central sources 
+- {: .dpgn-guideline-10-3 .dpgn-checklist} Assign data custodians to ensuring data is correct, consistent, and complete
+- {: .dpgn-guideline-10-2 .dpgn-checklist} Design data resiliency in accordance with GC policies and standards
+- {: .dpgn-guideline-10-2 .dpgn-checklist} Use Master Data Management to provide a single point of reference for appropriate stakeholders
+{: .dpgn-digital-architectural-keep-data-organized .dpgn-information-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
 
 {% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-keep-data-organized" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
@@ -98,9 +94,92 @@ This page provides personalized guidance for how projects can meet the Governmen
 
 <section>
 
-## 9. Use Cloud First
+<!-- markdownlint-disable MD022 -->
+### Enable Interoperability
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-cloud-first-1,dpgn-digital-architectural-cloud-first-2,dpgn-digital-architectural-cloud-first-3" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-cloud-first-1,dpgn-digital-architectural-cloud-first-2,dpgn-digital-architectural-cloud-first-3" guidelineSectionsOrder="checklist" %}
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-3 .dpgn-checklist} Expose all functionality as services
+- {: .dpgn-guideline-6-3 .dpgn-checklist} Use microservices built around business capabilities. Scope each service to a single purpose
+- {: .dpgn-guideline-6-3 .dpgn-checklist} Run each service in its own process and have it communicate with other services through a well-defined interface, such as an HTTPS-based application programming interface (API)
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Run applications in containers
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Leverage enterprise digital exchange components such as the GC Service Bus, Digital Exchange Platform, and the API Store based on fit-for-use
+{: .dpgn-digital-architectural-enable-interoperability .dpgn-information-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-enable-interoperability" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+## 3. Application Architecture
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Use Open Standards and Solutions by Default
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Use open source standards, solutions, components, and leading practices
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Enforce this order of preference: open source first, then platform-agnostic COTS, then proprietary COTS, and lastly custom-built
+- {: .dpgn-guideline-5-1 .dpgn-checklist} Make source code open and reusable under an appropriate open source software license
+- {: .dpgn-guideline-5-1 .dpgn-checklist} Expose public data to implement Open Data and Open Information initiatives
+{: .dpgn-digital-architectural-open-standards-solutions .dpgn-application-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-open-standards-solutions" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Maximize Reuse
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Leverage and reuse existing solutions, components, and processes
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Select enterprise and cluster solutions over department-specific solutions
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Achieve simplification by minimizing duplication of components and adhering to relevant standards
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Inform the GC EARB about departmental investments and innovations
+- {: .dpgn-guideline-5-1 .dpgn-checklist} Share code publicly when appropriate, and when not, share within the Government of Canada
+{: .dpgn-digital-architectural-maximize-reuse .dpgn-application-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-maximize-reuse" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+## 4. Technology Architecture
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Use Cloud first
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Enforce this order of preference: Software as a Service (SaaS) first, then Platform as a Service (PaaS), and lastly Infrastructure as a Service (IaaS)
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Enforce this order of preference: Public cloud first, then Hybrid cloud, then Private cloud, and lastly non-cloud (on-premises) solutions
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Design for cloud mobility and develop an exit strategy to avoid vendor lock-in
+{: .dpgn-digital-architectural-cloud-first .dpgn-technology-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
 
 {% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-cloud-first" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
@@ -108,10 +187,66 @@ This page provides personalized guidance for how projects can meet the Governmen
 
 <section>
 
-## 10. Security and Privacy by Design
+<!-- markdownlint-disable MD022 -->
+### Design for Performance, Availability, and Scalability
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-security-privacy-1,dpgn-digital-architectural-security-privacy-2,dpgn-digital-architectural-security-privacy-3,dpgn-digital-architectural-security-privacy-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-security-privacy-1,dpgn-digital-architectural-security-privacy-2,dpgn-digital-architectural-security-privacy-3,dpgn-digital-architectural-security-privacy-4" guidelineSectionsOrder="checklist" %}
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Design for resiliency
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Ensure response times meet user needs, and critical services are highly available
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Support zero-downtime deployments for planned and unplanned maintenance
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Use distributed architectures, assume failure will happen, handle errors gracefully, and monitor actively
+{: .dpgn-digital-architectural-performance-availability-scalability .dpgn-technology-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-performance-availability-scalability" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+## 5. Security Architecture and Privacy
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Design for Security and Privacy
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-9-4 .dpgn-checklist} Implement security across all architectural layers 
+- {: .dpgn-guideline-9-4 .dpgn-checklist} Categorize data properly to determine appropriate safeguards 
+- {: .dpgn-guideline-9-4 .dpgn-checklist} Perform a privacy impact assessment (PIA) when personal information is involved
+- {: .dpgn-guideline-9-1 .dpgn-checklist} Balance user and business needs with proportionate security measures
+{: .dpgn-digital-architectural-security-privacy .dpgn-security-architecture-privacy .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
 
 {% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-security-privacy" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Design Systems to be Measurable and Accountable
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-5-2 .dpgn-checklist} Publish a Service Level Agreement for each service
+- {: .dpgn-guideline-5-3 .dpgn-checklist} Make an audit trail available for all transactions to ensure accountability and non repudiation
+- {: .dpgn-guideline-5-3 .dpgn-checklist} Establish business and IT metrics to enable business outcomes
+- {: .dpgn-guideline-5-3 .dpgn-checklist} Apply oversight and lifecycle management to digital investments through governance
+{: .dpgn-digital-architectural-measurable-accountable .dpgn-security-architecture-privacy .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-measurable-accountable" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
 </section>

--- a/views-vues/gc-earb-ceai/fr/ceai-gc.md
+++ b/views-vues/gc-earb-ceai/fr/ceai-gc.md
@@ -10,87 +10,82 @@ collectionDirectory: views-vues/gc-earb-ceai
 Les normes architecturales sur le numérique du gouvernement du Canada s’appliqueront à tous les projets et toutes les initiatives afin de bien s’harmoniser avec l’orientation numérique du gouvernement du Canada. Le Comité d’examen de l’architecture intégrée du gouvernement du Canada (CEAI GC) se servira de ces normes pour évaluer les investissements et les solutions en matière de numérique. Les normes architecturales sur le numérique viennent compléter les normes sur le numérique du gouvernement du Canada, en misant sur les pratiques exemplaires qui visent la planification architecturale et la conception.
 
 Cette page fournit des conseils personnalisés sur la façon dont les projets peuvent répondre aux normes architecturales sur le numérique d'architecture numérique exigées du gouvernement du Canada par le Comité d’examen de l’architecture intégrée du gouvernement du Canada (CEAI GC).
+{: .dpgn-data-ignore}
 
 <!-- markdownlint-disable MD032 -->
 - TOC
-{:toc .lst-spcd}
+{:toc .lst-spcd .dpgn-data-ignore}
 <!-- markdownlint-enable MD032 -->
 
 <section>
 
-## 1. Se servir de normes et de solutions ouvertes par défaut
+<!-- markdownlint-disable MD022 -->
+## 1. Architecture d'entreprise
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-open-standards-solutions-1,dpgn-digital-architectural-open-standards-solutions-2,dpgn-digital-architectural-open-standards-solutions-3,dpgn-digital-architectural-open-standards-solutions-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-open-standards-solutions-1,dpgn-digital-architectural-open-standards-solutions-2,dpgn-digital-architectural-open-standards-solutions-3,dpgn-digital-architectural-open-standards-solutions-4" guidelineSectionsOrder="checklist" %}
+<section>
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-open-standards-solutions" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+<!-- markdownlint-disable MD022 -->
+### Aligner sur le modèle de capacité d’affaires du GC
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Définir les services de programme en tant que fonctionnalités métier permettant d'établir un vocabulaire commun entre les activités, le développement et les opérations
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Identifier les fonctionnalités communes à l'entreprise GC et pouvant être partagées et réutilisées
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Modélisation des processus métier à l'aide du langage de modélisation unifiée pour identifier les processus d'entreprise communs
+{: .dpgn-digital-architectural-align-gc-business-capability-model .dpgn-business-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-align-gc-business-capability-model" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
 </section>
 
 <section>
 
-## 2. Maximiser la réutilisation
+<!-- markdownlint-disable MD022 -->
+### Concevoir pour les utilisateurs d’abord et assurer la prestation à l’aide d’équipes multidisciplinaires
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-maximize-reuse-1,dpgn-digital-architectural-maximize-reuse-2,dpgn-digital-architectural-maximize-reuse-3,dpgn-digital-architectural-maximize-reuse-4,dpgn-digital-architectural-maximize-reuse-5" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-maximize-reuse-1,dpgn-digital-architectural-maximize-reuse-2,dpgn-digital-architectural-maximize-reuse-3,dpgn-digital-architectural-maximize-reuse-4,dpgn-digital-architectural-maximize-reuse-5" guidelineSectionsOrder="checklist" %}
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-1-2 .dpgn-checklist} Miser sur les besoins des utilisateurs; se servir de méthodes agiles, itératives et axées sur l’utilisateur
+- {: .dpgn-guideline-2-2 .dpgn-checklist} Se conformer aux exigences en matière d’accessibilité et de langues officielles
+- {: .dpgn-guideline-3-1 .dpgn-checklist} Tenir compte de toutes les compétences nécessaires à la prestation, y compris celles qui ont trait aux exigences, à la conception, à l’élaboration et aux opérations
+- {: .dpgn-guideline-4-4 .dpgn-checklist} Travailler de façon à couvrir le cycle de vie tout entier de l’application, de son élaboration à sa mise à l’essai, et du déploiement aux opérations
+- {: .dpgn-guideline-4-3 .dpgn-checklist} Veiller à ce que l’on tienne compte de la qualité tout au long du cycle de vie d’élaboration du logiciel
+- {: .dpgn-guideline-4-3 .dpgn-checklist} Encourager et adopter le développement piloté par les tests (DPT) pour améliorer la confiance qui règne entre les entreprises et la TI
+{: .dpgn-digital-architectural-design-for-users-first .dpgn-digital-architectural-multidisciplinary-teams .dpgn-business-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-maximize-reuse" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-design-for-users-first,dpgn-digital-architectural-multidisciplinary-teams" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
+</section>
 </section>
 
 <section>
 
-## 3. Concevoir pour les utilisateurs d’abord
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-design-for-users-first-1,dpgn-digital-architectural-design-for-users-first-2,dpgn-digital-architectural-design-for-users-first-3" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-design-for-users-first-1,dpgn-digital-architectural-design-for-users-first-2,dpgn-digital-architectural-design-for-users-first-3" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-design-for-users-first" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
+<!-- markdownlint-disable MD022 -->
+## 2. Architecture d'information
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
 <section>
 
-## 4. Assurer la prestation à l’aide d’équipes multidisciplinaires
+<!-- markdownlint-disable MD022 -->
+### Veiller à l’organisation des données
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-multidisciplinary-teams-1,dpgn-digital-architectural-multidisciplinary-teams-2,dpgn-digital-architectural-multidisciplinary-teams-3,dpgn-digital-architectural-multidisciplinary-teams-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-multidisciplinary-teams-1,dpgn-digital-architectural-multidisciplinary-teams-2,dpgn-digital-architectural-multidisciplinary-teams-3,dpgn-digital-architectural-multidisciplinary-teams-4" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-multidisciplinary-teams" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
-
-<section>
-
-## 5. Concevoir à des fins de rendement, de disponibilité et d’échelonnabilité
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-performance-availability-scalability-1,dpgn-digital-architectural-performance-availability-scalability-2,dpgn-digital-architectural-performance-availability-scalability-3,dpgn-digital-architectural-performance-availability-scalability-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-performance-availability-scalability-1,dpgn-digital-architectural-performance-availability-scalability-2,dpgn-digital-architectural-performance-availability-scalability-3,dpgn-digital-architectural-performance-availability-scalability-4" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-performance-availability-scalability" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
-
-<section>
-
-## 6. Permettre l’interopérabilité
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-enable-interoperability-1,dpgn-digital-architectural-enable-interoperability-2,dpgn-digital-architectural-enable-interoperability-3,dpgn-digital-architectural-enable-interoperability-4,dpgn-digital-architectural-enable-interoperability-5" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-enable-interoperability-1,dpgn-digital-architectural-enable-interoperability-2,dpgn-digital-architectural-enable-interoperability-3,dpgn-digital-architectural-enable-interoperability-4,dpgn-digital-architectural-enable-interoperability-5" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-enable-interoperability" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
-
-<section>
-
-## 7. Concevoir des systèmes mesurables et responsables
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-measurable-accountable-1,dpgn-digital-architectural-measurable-accountable-2,dpgn-digital-architectural-measurable-accountable-3,dpgn-digital-architectural-measurable-accountable-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-measurable-accountable-1,dpgn-digital-architectural-measurable-accountable-2,dpgn-digital-architectural-measurable-accountable-3,dpgn-digital-architectural-measurable-accountable-4" guidelineSectionsOrder="checklist" %}
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-measurable-accountable" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
-
-</section>
-
-<section>
-
-## 8. Veiller à l’organisation des données
-
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-keep-data-organized-1,dpgn-digital-architectural-keep-data-organized-2,dpgn-digital-architectural-keep-data-organized-3,dpgn-digital-architectural-keep-data-organized-4,dpgn-digital-architectural-keep-data-organized-5" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-keep-data-organized-1,dpgn-digital-architectural-keep-data-organized-2,dpgn-digital-architectural-keep-data-organized-3,dpgn-digital-architectural-keep-data-organized-4,dpgn-digital-architectural-keep-data-organized-5" guidelineSectionsOrder="checklist" %}
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-10-2 .dpgn-checklist} Dissocier les données de base des applications et de l’hôte au sein d’un système d’enregistrement approprié
+- {: .dpgn-guideline-10-2 .dpgn-checklist} Veiller à ce que les systèmes d’enregistrement des sources centrales fassent autorité
+- {: .dpgn-guideline-10-3 .dpgn-checklist} Assigner des gardiens des données afin de veiller à ce que les données soient précises, uniformes et intégrales
+- {: .dpgn-guideline-10-2 .dpgn-checklist} Concevoir la résilience des données conformément aux politiques et normes du GC
+- {: .dpgn-guideline-10-2 .dpgn-checklist} Se servir de la gestion des données de base pour fournir un point de référence unique à l’intention des intervenants pertinents
+{: .dpgn-digital-architectural-keep-data-organized .dpgn-information-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
 
 {% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-keep-data-organized" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
@@ -98,9 +93,92 @@ Cette page fournit des conseils personnalisés sur la façon dont les projets pe
 
 <section>
 
-## 9. Se servir du nuage d’abord
+<!-- markdownlint-disable MD022 -->
+### Permettre l’interopérabilité
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-cloud-first-1,dpgn-digital-architectural-cloud-first-2,dpgn-digital-architectural-cloud-first-3" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-cloud-first-1,dpgn-digital-architectural-cloud-first-2,dpgn-digital-architectural-cloud-first-3" guidelineSectionsOrder="checklist" %}
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-3 .dpgn-checklist} Exposer toutes les fonctionnalités en tant que services
+- {: .dpgn-guideline-6-3 .dpgn-checklist} Se servir de microservices ayant été conçus autour des capacités opérationnelles. Concevoir chaque servir à une fin particulière
+- {: .dpgn-guideline-6-3 .dpgn-checklist} Exploiter chaque service selon son propre processus, et veiller à ce qu’il communique avec les autres services par l’entremise d’une interface bien définie, comme une Interface de programmation d’applications (IPA) axée sur un protocole HTTPS
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Faire rouler les applications en conteneurs
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Tirer parti des composantes intégrées d’échange numérique comme le Bus de service du GC, la plateforme d’échange numérique, et le magasin IPA, conçu à des fins d’utilisation sur mesure
+{: .dpgn-digital-architectural-enable-interoperability .dpgn-information-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-enable-interoperability" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+## 3. Architecture d'application
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Se servir de normes et de solutions ouvertes par défaut
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Se servir de normes, solutions, composantes et pratiques de pointe en matière de source ouverte
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Préconiser cet ordre de préférences : source ouverte d’abord, puis les logiciels disponibles sur le marché qui sont indifférents à la plateforme, puis les logiciels disponibles sur le marché exclusifs, puis en dernier lieu, les logiciels conçus sur mesure
+- {: .dpgn-guideline-5-1 .dpgn-checklist} Rendre le code source ouvert et réutilisable en vertu d’une licence de logiciel à source ouverte
+- {: .dpgn-guideline-5-1 .dpgn-checklist} Exposer les données publiques afin de procéder à la mise en œuvre d’initiatives sur les données ouvertes et l’information ouverte
+{: .dpgn-digital-architectural-open-standards-solutions .dpgn-application-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-open-standards-solutions" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Maximiser la réutilisation
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Tirer parti et réutiliser les solutions, composantes et processus qui existent déjà
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Sélectionner des solutions intégrées et regroupées avant d’opter pour des solutions spécifiques à un ministère
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Réaliser la simplification en minimisant le dédoublement des composantes et en s’en tenant aux normes pertinentes
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Informer le CEAI GC des investissements et des innovations ministériels
+- {: .dpgn-guideline-5-1 .dpgn-checklist} Partager le code publiquement lorsqu’il est approprié de le faire et, lorsqu’il n’est pas pratique de le faire, le partager au sein du gouvernement du Canada
+{: .dpgn-digital-architectural-maximize-reuse .dpgn-application-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-maximize-reuse" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+## 4. Architecture de la technologie
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Se servir du nuage d’abord
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Préconiser cet ordre de préférences : Logiciel comme service (SaaS) d’abord, puis Plateforme comme service (PaaS), et en dernier lieu, l’Infrastructure comme service (IaaS)
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Préconiser cet ordre de préférences : Le nuage public d’abord, ensuite, le nuage hybride, puis le nuage privé et, en dernier lieu, les solutions non nuagiques (sur site)
+- {: .dpgn-guideline-6-2 .dpgn-checklist} Concevoir en vue d’une mobilité nuagique, et élaborer une stratégie de sortie afin d’éviter l’enfermement propriétaire
+{: .dpgn-digital-architectural-cloud-first .dpgn-technology-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
 
 {% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-cloud-first" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
@@ -108,10 +186,66 @@ Cette page fournit des conseils personnalisés sur la façon dont les projets pe
 
 <section>
 
-## 10. Concevoir en vue de la sécurité et de la protection des renseignements personnels
+<!-- markdownlint-disable MD022 -->
+### Concevoir à des fins de rendement, de disponibilité et d’échelonnabilité
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
 
-{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-security-privacy-1,dpgn-digital-architectural-security-privacy-2,dpgn-digital-architectural-security-privacy-3,dpgn-digital-architectural-security-privacy-4" groupListsSeparately=true groupByTagsTags="dpgn-digital-architectural-security-privacy-1,dpgn-digital-architectural-security-privacy-2,dpgn-digital-architectural-security-privacy-3,dpgn-digital-architectural-security-privacy-4" guidelineSectionsOrder="checklist" %}
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Concevoir à des fins de résilience
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Veiller à ce que les temps de réponse répondent aux besoins des utilisateurs, et que les services critiques soient grandement disponibles
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Appuyer les déploiements sans temps morts, dans les cas de maintenance planifiée et non planifiée
+- {: .dpgn-guideline-6-1 .dpgn-checklist} Se servir d’architectures distribuées, en présumant que des échecs se produiront, traiter des erreurs avec dignité, et surveiller activement
+{: .dpgn-digital-architectural-performance-availability-scalability .dpgn-technology-architecture .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-performance-availability-scalability" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+## 5. Architecture de sécurité et de la protection des renseignements personnels
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Concevoir en vue de la sécurité et de la protection des renseignements personnels
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-9-4 .dpgn-checklist} Procéder à la mise en œuvre de la sécurité à l’échelle de tous les niveaux de l’architecture
+- {: .dpgn-guideline-9-4 .dpgn-checklist} Catégoriser les données correctement afin de déterminer les mécanismes de protection qui s’imposent
+- {: .dpgn-guideline-9-4 .dpgn-checklist} Mener une Évaluation des facteurs relatifs à la vie privée (ÉFVP) lorsque des renseignements personnels sont en jeu
+- {: .dpgn-guideline-9-1 .dpgn-checklist} Équilibrer les besoins des utilisateurs aux besoins organisationnels en se dotant de mesures de sécurité proportionnelles
+{: .dpgn-digital-architectural-security-privacy .dpgn-security-architecture-privacy .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
 
 {% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-security-privacy" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
 
+</section>
+
+<section>
+
+<!-- markdownlint-disable MD022 -->
+### Concevoir des systèmes mesurables et responsables
+{: .dpgn-data-ignore}
+<!-- markdownlint-enable MD022 -->
+
+<!-- markdownlint-disable MD032 -->
+- {: .dpgn-guideline-5-2 .dpgn-checklist} Publier un accord sur les niveaux de service pour chaque service
+- {: .dpgn-guideline-5-3 .dpgn-checklist} Veiller à ce qu’une piste d’audit soit disponible pour toutes les transactions, afin d’assurer la responsabilisation et la non-répudiation
+- {: .dpgn-guideline-5-3 .dpgn-checklist} Établir des paramètres opérationnels et de la TI afin de faciliter l’atteinte de résultats opérationnels
+- {: .dpgn-guideline-5-3 .dpgn-checklist} Appliquer des principes de surveillance et de gestion du cycle de vie aux investissements numériques par l’entremise de la gouvernance
+{: .dpgn-digital-architectural-measurable-accountable .dpgn-security-architecture-privacy .dpgn-digital-architectural}
+<!-- markdownlint-enable MD032 -->
+
+{% include /functions/output-sections.html parentHeadingLevel="2" relevantTags="dpgn-digital-architectural-measurable-accountable" groupListsSeparately=true guidelineSectionsOrder="guides,solutions" %}
+
+</section>
 </section>


### PR DESCRIPTION
- Updated to the latest English and French versions
- Moved content from Digital Standards files to the view files, with references back to the guidelines