### PR TITLE
Fix french assurance levels

### DIFF
--- a/_includes/views-vues.html
+++ b/_includes/views-vues.html
@@ -117,7 +117,7 @@ if include.lang == "en" or include.lang.size < 2 and page.lang == "en" %}
 <section class="dpgn-data-ignore">
   <h4 class="dpgn-data-ignore">Exigence relative au niveau d’assurance</h4>
   <ul class="dpgn-data-ignore list-unstyled">
-        <li><a class="btn btn-default btn-lg mrgn-bttm-md" href="{{ site.baseurl }}/views-vues/assurance-level-requirement/en/assurance-level-requirement.html"><span class="btn-block text-left"><span class="glyphicon glyphicon-check mrgn-rght-sm" aria-hidden="true"></span>Create Assurance Level Document (draft) TODO</span></a><span class="hidden"> (Keywords: Assurance level TODO)</span></li>
+        <li><a class="btn btn-default btn-lg mrgn-bttm-md" href="{{ site.baseurl }}/views-vues/assurance-level-requirement/fr/assurance-level-requirement.html"><span class="btn-block text-left"><span class="glyphicon glyphicon-check mrgn-rght-sm" aria-hidden="true"></span>Créer un document de niveau d’assurance (ébauche)</span></a><span class="hidden"> (Keywords: Niveau d’assurance)</span></li>
   </ul>
 </section>
 

--- a/_includes/views-vues.html
+++ b/_includes/views-vues.html
@@ -117,7 +117,7 @@ if include.lang == "en" or include.lang.size < 2 and page.lang == "en" %}
 <section class="dpgn-data-ignore">
   <h4 class="dpgn-data-ignore">Exigence relative au niveau d’assurance</h4>
   <ul class="dpgn-data-ignore list-unstyled">
-        <li><a class="btn btn-default btn-lg mrgn-bttm-md" href="{{ site.baseurl }}/views-vues/assurance-level-requirement/fr/assurance-level-requirement.html"><span class="btn-block text-left"><span class="glyphicon glyphicon-check mrgn-rght-sm" aria-hidden="true"></span>Créer un document de niveau d’assurance (ébauche)</span></a><span class="hidden"> (Keywords: Niveau d’assurance)</span></li>
+        <li><a class="btn btn-default btn-lg mrgn-bttm-md" href="{{ site.baseurl }}/views-vues/assurance-level-requirement/fr/niveau-d'assurance.html"><span class="btn-block text-left"><span class="glyphicon glyphicon-check mrgn-rght-sm" aria-hidden="true"></span>Créer un document de niveau d’assurance (ébauche)</span></a><span class="hidden"> (Keywords: Niveau d’assurance)</span></li>
   </ul>
 </section>
 

--- a/_includes/views-vues/assurance-level-requirement/assurance-level-post.html
+++ b/_includes/views-vues/assurance-level-requirement/assurance-level-post.html
@@ -4,10 +4,7 @@
 <h2>{{ page.afterwards }}</h2>
 
 <p>
-  The following table outlines what departments should do when a selected
-  authentication option is equal to the assurance level requirement determined
-  above and when the selected option is lower than the assurance level
-  requirement determined above.
+  {{page.postOpening}}
 </p>
 
 <!-- Options Header -->

--- a/_includes/views-vues/assurance-level-requirement/assurance-level-questionnaire.html
+++ b/_includes/views-vues/assurance-level-requirement/assurance-level-questionnaire.html
@@ -22,7 +22,7 @@
           </li>
         {%- endif -%}
       {%- endfor -%}
-      <li data-wb-fieldflow='{ "action": "removeClass", "source": "#table-question-{{ question }}-level-NA, #table-question-{{ question }}-assessment-NA, #table-question-{{ question }}-harm-NA", "class": "hidden" }'>{{ page.notApplicable }}</li>
+      <li data-wb-fieldflow='{ "action": "removeClass", "source": "#table-question-{{ question }}-level-NA, #table-question-{{ question }}-assessment-NA, #table-question-{{ question }}-harm-NA", "class": "hidden" }'>{{ site.NotApplicable[page.lang] }}</li>
     </ul>
   </div>
   {%- for level in (1..4) -%}{%
@@ -31,7 +31,7 @@
     {%- if page.questions[ questionAnswerString ] -%}
     <section id="hint-panel-{{ question }}-level-{{ level }}" class="wb-overlay modal-content overlay-def wb-bar-b">
       <header class="modal-header">
-        <h2 class="modal-title">Harms for Question-{{ question }} Level-{{ level }}</h2>
+        <h2 class="modal-title">{{ page.potentialHarm }} {{ site.Question[page.lang] }}-{{ question }} {{ site.Level[page.lang]}}-{{ level }}</h2>
       </header>
       <div class="modal-body">
         {{ page.questions[ questionHintString ] }}

--- a/_includes/views-vues/assurance-level-requirement/assurance-level-resultats.html
+++ b/_includes/views-vues/assurance-level-requirement/assurance-level-resultats.html
@@ -50,7 +50,7 @@
   {% for level in (1..4) %}
   <div id="table-question-{{ question }}-level-{{ level }}" class="hidden assurance-level-element"> {{ level }}</div>
   {% endfor %}
-  <div id="table-question-{{ question }}-level-NA"> N/A</div>
+  <div id="table-question-{{ question }}-level-NA"> {{ page.notApplicableAbbr }}</div>
 </td>
   <!-- Assessment Strings -->
 <td class="table-question-{{ question }}-assessment">
@@ -109,7 +109,7 @@ endfor %}
 </table>
 </div>
 
-<button type="button" class="btn btn-default" onclick="javascript:PrintElem($( '#table-results-div' ), 'LOA Assessment - ' + $('#table-detail-3').text() + ' - ' + $('#table-detail-2').text());">Print / Download PDF</button>
+<button type="button" class="btn btn-default" onclick="javascript:PrintElem($( '#table-results-div' ), 'LOA Assessment - ' + $('#table-detail-3').text() + ' - ' + $('#table-detail-2').text());">{{ page.printButton }}</button>
 <button type="button" class="btn btn-default wb-format-gen" data-wb-format-gen='{ "type": "csv", "rowSelector": "tr", "colSelector": "th, td div:not(.hidden)", "container": "#table-results-div", "filename": "assurance-level-assessment" }'>{{ site.DownloadCSV[page.lang] }}</button>
 
 </section>

--- a/views-vues/assurance-level-requirement/en/assurance-level-requirement.html
+++ b/views-vues/assurance-level-requirement/en/assurance-level-requirement.html
@@ -175,12 +175,15 @@ overallAssessment: Overall Assessment
 
 detailTitle: Details
 assuranceTitle: Assurance Levels
+notApplicableAbbr: N/A
 
 assuranceQuestion: To determine the level of assurance required, complete the following sentence using the statements in the cells below and check the appropriate boxes
 assuranceSentence: "If the program, activity, service or transaction above is compromised, it could result in…"
-notApplicable: Not Applicable
+
+printButton: Print / Download PDF
 
 afterwards: Afterwards
+postOpening: The following table outlines what departments should do when a selected authentication option is equal to the assurance level requirement determined above and when the selected option is lower than the assurance level requirement determined above.
 
 authentication: Authentication Option
 implementation: Implementation Option

--- a/views-vues/assurance-level-requirement/fr/niveau-d'assurance.html
+++ b/views-vues/assurance-level-requirement/fr/niveau-d'assurance.html
@@ -5,7 +5,7 @@ lang: fr
 altLang: en
 altLangPage: assurance-level-requirement
 collectionDirectory: views-vues/assurance-level-requirement
-version: Assessment Version 1.0
+version: Version d’évaluation 1.0
 
 moreInfo: Plus d’information
 questions:
@@ -175,12 +175,15 @@ overallAssessment: Évaluation Globale
 
 detailTitle: Détails
 assuranceTitle: Niveaux d’Assurance
+notApplicableAbbr: S/O
 
 assuranceQuestion: Pour déterminer le niveau d’assurance requis, complétez la phrase suivante en utilisant les énoncés dans les cellules ci-dessous et en cochant les cases appropriées
 assuranceSentence: « Si le programme, l’activité, le service ou l’opération ci-dessus est compromis, cela pourrait entraîner… »
-notApplicable: N’est pas Applicable
+
+printButton: Imprimer / télécharger le PDF
 
 afterwards: Ensuite
+postOpening: Le tableau suivant décrit ce que les ministères doivent faire lorsqu’une option d’authentification choisie est égale à l’exigence relative au niveau d’assurance déterminé ci-dessus et lorsque l’option choisie est inférieure à l’exigence relative au niveau d’assurance déterminé ci-dessus.
 
 authentication: Option d’authentification
 implementation: Option de mise en œuvre

--- a/views-vues/assurance-level-requirement/fr/niveau-d'assurance.html
+++ b/views-vues/assurance-level-requirement/fr/niveau-d'assurance.html
@@ -7,7 +7,7 @@ altLangPage: assurance-level-requirement
 collectionDirectory: views-vues/assurance-level-requirement
 version: Assessment Version 1.0
 
-moreInfo: Plus d'information
+moreInfo: Plus d’information
 questions:
   "1": Inconvénients, détresse, perte de situation sociale ou de réputation
   "1-a1": Des inconvénients, de la détresse ou des dommages à la situation sociale ou à la réputation d’une partie.
@@ -174,11 +174,11 @@ potentialHarm: Risque de Préjudice
 overallAssessment: Évaluation Globale
 
 detailTitle: Détails
-assuranceTitle: Niveaux d'Assurance
+assuranceTitle: Niveaux d’Assurance
 
 assuranceQuestion: Pour déterminer le niveau d’assurance requis, complétez la phrase suivante en utilisant les énoncés dans les cellules ci-dessous et en cochant les cases appropriées
 assuranceSentence: « Si le programme, l’activité, le service ou l’opération ci-dessus est compromis, cela pourrait entraîner… »
-notApplicable: N'est pas Applicable
+notApplicable: N’est pas Applicable
 
 afterwards: Ensuite
 


### PR DESCRIPTION
This patch: 

* translates the remaining English found on the tool
* fixes an display error caused by use of ' instead of ’ in French text
* fixes the landing page link to the French page (was still directing to the English page)